### PR TITLE
Adds simple caching functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,21 @@ const doc = await resolver.resolve('did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkq
 
 ## Caching
 
-Resolving DID Documents can be expensive. It is in most cases best to cache DID documents. By default caching is now enabled in the resolver.
+Resolving DID Documents can be expensive. It is in most cases best to cache DID documents. Caching has to be specifically enabled using the `cache` parameter
 
-The built in cache uses a WeakMap, but does not have an automatic TTL, so entries don't expire. This is fine in most web, mobile and serverless contexts. If you run a long running process you may want to use an existing configurable caching system.
+The built in cache uses a Map, but does not have an automatic TTL, so entries don't expire. This is fine in most web, mobile and serverless contexts. If you run a long running process you may want to use an existing configurable caching system.
+
+The built in Cache can be enabled by passing in a `true` value to the constructor:
+
+```js
+const resolver = new DIDResolver({
+  ethr,
+  web
+}, true)
+```
 
 Here is an example using `js-cache` which has not been tested.
+
 
 ```js
 var cache = require('js-cache')
@@ -67,16 +77,6 @@ const resolver = new DIDResolver({
   web
 }, customCache)
 ```
-
-The Cache can also be disabled by passing in a `false` value to the constructor:
-
-```js
-const resolver = new DIDResolver({
-  ethr,
-  web
-}, false)
-```
-
 
 ## Implementing a DID method
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -68,13 +68,13 @@ interface ResolverRegistry {
 }
 
 export function inMemoryCache() : DIDCache {
-  const cache: WeakMap<ParsedDID, DIDDocument|null> = new WeakMap()
+  const cache: Map<String, DIDDocument|null> = new Map()
   return async (parsed, resolve) => {
     if (parsed.params && parsed.params['no-cache'] === 'true') return await resolve()
-    const cached = cache.get(parsed)
+    const cached = cache.get(parsed.did)
     if (cached !== undefined) return cached
     const doc = await resolve()
-    cache.set(parsed, doc)
+    cache.set(parsed.did, doc)
     return doc
   }
 }
@@ -120,9 +120,9 @@ export class Resolver {
 
   constructor(registry: ResolverRegistry = {}, cache?: DIDCache|boolean|undefined) {
     this.registry = registry
-    this.cache = cache === true || cache === undefined
+    this.cache = cache === true
       ? inMemoryCache()
-      : (cache === false ? noCache : cache)
+      : cache || noCache    
   }
 
   resolve(didUrl: string): Promise<DIDDocument | null> {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -68,7 +68,7 @@ interface ResolverRegistry {
 }
 
 export function inMemoryCache() : DIDCache {
-  const cache: Map<String, DIDDocument|null> = new Map()
+  const cache: Map<string, DIDDocument|null> = new Map()
   return async (parsed, resolve) => {
     if (parsed.params && parsed.params['no-cache'] === 'true') return await resolve()
     const cached = cache.get(parsed.did)


### PR DESCRIPTION
Resolving DID Documents can be expensive. It is in most cases best to cache DID documents. By default caching is now enabled in the resolver.

It depends on #9 to support `no-cache` param.

The built in cache uses a WeakMap, but does not have an automatic TTL, so entries don't expire. This is fine in most web, mobile and serverless contexts. If you run a long running process you may want to use an existing configurable caching system.

Here is an example using `js-cache` which has not been tested.

```js
var cache = require('js-cache')
const customCache : DIDCache = (parsed, resolve) => {
  // DID spec requires to not cache if no-cache param is set
  if (parsed.params && parsed.params['no-cache'] === 'true') return await resolve()
  const cached = cache.get(parsed.didUrl)
  if (cached !== undefined) return cached
  const doc = await resolve()
  cache.set(parsed, doc, 60000)
  return doc
}

const resolver = new DIDResolver({
  ethr,
  web
}, customCache)
```

The Cache can also be disabled by passing in a `false` value to the constructor:

```js
const resolver = new DIDResolver({
  ethr,
  web
}, false)
```