### PR TITLE
Fix typing in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export function getResolver() {
   async function resolve(
     did: string,
     parsed: ParsedDID,
-    didResolver: DIDResolver
+    didResolver: Resolver
   ): Promise<DIDDocument | null> {
     console.log(parsed)
     // {method: 'mymethod', id: 'abcdefg', did: 'did:mymethod:abcdefg/some/path#fragment=123', path: '/some/path', fragment: 'fragment=123'}


### PR DESCRIPTION
The type for the `didResolver` argument is not `DIDResolver` but `Resolver`. This can cause confusion when using this template to implement own DID resolvers.