### PR TITLE
fix: return non-null DIDDocument on Resolver.resolve()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib
 .vscode/settings.json
 coverage
 .idea/
+.vscode/
 
 *.log
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ export function getResolver() {
     did: string,
     parsed: ParsedDID,
     didResolver: Resolver
-  ): Promise<DIDDocument | null> {
+  ): Promise<DIDDocument> {
     console.log(parsed)
     // {method: 'mymethod', id: 'abcdefg', did: 'did:mymethod:abcdefg/some/path#fragment=123', path: '/some/path', fragment: 'fragment=123'}
     const didDoc = ...// lookup doc

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.5.0"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
@@ -19,20 +19,20 @@
       "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "@babel/generator": "7.5.5",
-        "@babel/helpers": "7.5.5",
-        "@babel/parser": "7.5.5",
-        "@babel/template": "7.4.4",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5",
-        "convert-source-map": "1.6.0",
-        "debug": "4.1.1",
-        "json5": "2.1.0",
-        "lodash": "4.17.15",
-        "resolve": "1.12.0",
-        "semver": "5.7.0",
-        "source-map": "0.5.7"
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helpers": "^7.5.5",
+        "@babel/parser": "^7.5.5",
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -41,7 +41,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -64,11 +64,11 @@
       "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.5.5",
-        "jsesc": "2.5.2",
-        "lodash": "4.17.15",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "@babel/types": "^7.5.5",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -85,12 +85,12 @@
       "integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-member-expression-to-functions": "7.5.5",
-        "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-replace-supers": "7.5.5",
-        "@babel/helper-split-export-declaration": "7.4.4"
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4"
       }
     },
     "@babel/helper-function-name": {
@@ -99,9 +99,9 @@
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0",
-        "@babel/template": "7.4.4",
-        "@babel/types": "7.5.5"
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -110,7 +110,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -119,7 +119,7 @@
       "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-module-imports": {
@@ -128,7 +128,7 @@
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -137,7 +137,7 @@
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -152,10 +152,10 @@
       "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.5.5",
-        "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -164,7 +164,7 @@
       "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/helpers": {
@@ -173,9 +173,9 @@
       "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.4.4",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/highlight": {
@@ -184,9 +184,9 @@
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "esutils": "2.0.3",
-        "js-tokens": "4.0.0"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
@@ -201,8 +201,8 @@
       "integrity": "sha512-/4FKFChkQ2Jgb8lBDsvFX496YTi7UWTetVgS8oJUpX1e/DlaoeEK57At27ug8Hu2zI2g8bzkJ+8k9qrHZRPGPA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "7.5.5",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-create-class-features-plugin": "^7.2.1",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-jsx": {
@@ -211,7 +211,7 @@
       "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -220,7 +220,7 @@
       "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/polyfill": {
@@ -229,8 +229,8 @@
       "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
       "dev": true,
       "requires": {
-        "core-js": "2.6.9",
-        "regenerator-runtime": "0.13.3"
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {
@@ -239,9 +239,9 @@
       "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "@babel/parser": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/traverse": {
@@ -250,15 +250,15 @@
       "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "@babel/generator": "7.5.5",
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-split-export-declaration": "7.4.4",
-        "@babel/parser": "7.5.5",
-        "@babel/types": "7.5.5",
-        "debug": "4.1.1",
-        "globals": "11.12.0",
-        "lodash": "4.17.15"
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -267,7 +267,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -284,9 +284,9 @@
       "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.3",
-        "lodash": "4.17.15",
-        "to-fast-properties": "2.0.0"
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@cnakazawa/watch": {
@@ -295,8 +295,8 @@
       "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
       "dev": true,
       "requires": {
-        "exec-sh": "0.3.2",
-        "minimist": "1.2.0"
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
       }
     },
     "@commitlint/cli": {
@@ -305,10 +305,10 @@
       "integrity": "sha512-8fJ5pmytc38yw2QWbTTJmXLfSiWPwMkHH4govo9zJ/+ERPBF2jvlxD/dQvk24ezcizjKc6LFka2edYC4OQ+Dgw==",
       "dev": true,
       "requires": {
-        "@commitlint/format": "8.2.0",
-        "@commitlint/lint": "8.2.0",
-        "@commitlint/load": "8.2.0",
-        "@commitlint/read": "8.2.0",
+        "@commitlint/format": "^8.2.0",
+        "@commitlint/lint": "^8.2.0",
+        "@commitlint/load": "^8.2.0",
+        "@commitlint/read": "^8.2.0",
         "babel-polyfill": "6.26.0",
         "chalk": "2.4.2",
         "get-stdin": "7.0.0",
@@ -367,7 +367,7 @@
       "integrity": "sha512-sA77agkDEMsEMrlGhrLtAg8vRexkOofEEv/CZX+4xlANyAz2kNwJvMg33lcL65CBhqKEnRRJRxfZ1ZqcujdKcQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2"
+        "chalk": "^2.0.1"
       }
     },
     "@commitlint/is-ignored": {
@@ -376,7 +376,7 @@
       "integrity": "sha512-ADaGnKfbfV6KD1pETp0Qf7XAyc75xTy3WJlbvPbwZ4oPdBMsXF0oXEEGMis6qABfU2IXan5/KAJgAFX3vdd0jA==",
       "dev": true,
       "requires": {
-        "@types/semver": "6.2.0",
+        "@types/semver": "^6.0.1",
         "semver": "6.2.0"
       },
       "dependencies": {
@@ -394,10 +394,10 @@
       "integrity": "sha512-ch9JN8aR37ufdjoWv50jLfvFz9rWMgLW5HEkMGLsM/51gjekmQYS5NJg8S2+6F5+jmralAO7VkUMI6FukXKX0A==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "8.2.0",
-        "@commitlint/parse": "8.2.0",
-        "@commitlint/rules": "8.2.0",
-        "babel-runtime": "6.26.0",
+        "@commitlint/is-ignored": "^8.2.0",
+        "@commitlint/parse": "^8.2.0",
+        "@commitlint/rules": "^8.2.0",
+        "babel-runtime": "^6.23.0",
         "lodash": "4.17.14"
       },
       "dependencies": {
@@ -415,13 +415,13 @@
       "integrity": "sha512-EV6PfAY/p83QynNd1llHxJiNxKmp43g8+7dZbyfHFbsGOdokrCnoelAVZ+WGgktXwLN/uXyfkcIAxwac015UYw==",
       "dev": true,
       "requires": {
-        "@commitlint/execute-rule": "8.2.0",
-        "@commitlint/resolve-extends": "8.2.0",
-        "babel-runtime": "6.26.0",
+        "@commitlint/execute-rule": "^8.2.0",
+        "@commitlint/resolve-extends": "^8.2.0",
+        "babel-runtime": "^6.23.0",
         "chalk": "2.4.2",
-        "cosmiconfig": "5.2.1",
+        "cosmiconfig": "^5.2.0",
         "lodash": "4.17.14",
-        "resolve-from": "5.0.0"
+        "resolve-from": "^5.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -450,9 +450,9 @@
       "integrity": "sha512-vzouqroTXG6QXApkrps0gbeSYW6w5drpUk7QAeZIcaCSPsQXDM8eqqt98ZzlzLJHo5oPNXPX1AAVSTrssvHemA==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.6.6",
-        "conventional-commits-parser": "2.1.7",
-        "lodash": "4.17.15"
+        "conventional-changelog-angular": "^1.3.3",
+        "conventional-commits-parser": "^2.1.0",
+        "lodash": "^4.17.11"
       }
     },
     "@commitlint/read": {
@@ -461,10 +461,10 @@
       "integrity": "sha512-1tBai1VuSQmsOTsvJr3Fi/GZqX3zdxRqYe/yN4i3cLA5S2Y4QGJ5I3l6nGZlKgm/sSelTCVKHltrfWU8s5H7SA==",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "8.2.0",
-        "@marionebl/sander": "0.6.1",
-        "babel-runtime": "6.26.0",
-        "git-raw-commits": "1.3.6"
+        "@commitlint/top-level": "^8.2.0",
+        "@marionebl/sander": "^0.6.0",
+        "babel-runtime": "^6.23.0",
+        "git-raw-commits": "^1.3.0"
       }
     },
     "@commitlint/resolve-extends": {
@@ -473,11 +473,11 @@
       "integrity": "sha512-cwi0HUsDcD502HBP8huXfTkVuWmeo1Fiz3GKxNwMBBsJV4+bKa7QrtxbNpXhVuarX7QjWfNTvmW6KmFS7YK9uw==",
       "dev": true,
       "requires": {
-        "@types/node": "12.7.1",
-        "import-fresh": "3.1.0",
+        "@types/node": "^12.0.2",
+        "import-fresh": "^3.0.0",
         "lodash": "4.17.14",
-        "resolve-from": "5.0.0",
-        "resolve-global": "1.0.0"
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0"
       },
       "dependencies": {
         "import-fresh": {
@@ -486,8 +486,8 @@
           "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
           "dev": true,
           "requires": {
-            "parent-module": "1.0.1",
-            "resolve-from": "4.0.0"
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
           },
           "dependencies": {
             "resolve-from": {
@@ -518,10 +518,10 @@
       "integrity": "sha512-FlqSBBP2Gxt5Ibw+bxdYpzqYR6HI8NIBpaTBhAjSEAduQtdWFMOhF0zsgkwH7lHN7opaLcnY2fXxAhbzTmJQQA==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "8.2.0",
-        "@commitlint/message": "8.2.0",
-        "@commitlint/to-lines": "8.2.0",
-        "babel-runtime": "6.26.0"
+        "@commitlint/ensure": "^8.2.0",
+        "@commitlint/message": "^8.2.0",
+        "@commitlint/to-lines": "^8.2.0",
+        "babel-runtime": "^6.23.0"
       }
     },
     "@commitlint/to-lines": {
@@ -536,7 +536,7 @@
       "integrity": "sha512-Yaw4KmYNy31/HhRUuZ+fupFcDalnfpdu4JGBgGAqS9aBHdMSSWdWqtAaDaxdtWjTZeN3O0sA2gOhXwvKwiDwvw==",
       "dev": true,
       "requires": {
-        "find-up": "4.1.0"
+        "find-up": "^4.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -545,8 +545,8 @@
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "5.0.0",
-            "path-exists": "4.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "locate-path": {
@@ -555,7 +555,7 @@
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
-            "p-locate": "4.1.0"
+            "p-locate": "^4.1.0"
           }
         },
         "p-locate": {
@@ -564,7 +564,7 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "2.2.1"
+            "p-limit": "^2.2.0"
           }
         },
         "path-exists": {
@@ -581,9 +581,9 @@
       "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
       "dev": true,
       "requires": {
-        "@jest/source-map": "24.9.0",
-        "chalk": "2.4.2",
-        "slash": "2.0.0"
+        "@jest/source-map": "^24.9.0",
+        "chalk": "^2.0.1",
+        "slash": "^2.0.0"
       }
     },
     "@jest/core": {
@@ -592,34 +592,34 @@
       "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
       "dev": true,
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/reporters": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "graceful-fs": "4.2.1",
-        "jest-changed-files": "24.9.0",
-        "jest-config": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-resolve-dependencies": "24.9.0",
-        "jest-runner": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-snapshot": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-validate": "24.9.0",
-        "jest-watcher": "24.9.0",
-        "micromatch": "3.1.10",
-        "p-each-series": "1.0.0",
-        "realpath-native": "1.1.0",
-        "rimraf": "2.7.1",
-        "slash": "2.0.0",
-        "strip-ansi": "5.2.0"
+        "@jest/console": "^24.7.1",
+        "@jest/reporters": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-changed-files": "^24.9.0",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-resolve-dependencies": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "jest-watcher": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "p-each-series": "^1.0.0",
+        "realpath-native": "^1.1.0",
+        "rimraf": "^2.5.4",
+        "slash": "^2.0.0",
+        "strip-ansi": "^5.0.0"
       }
     },
     "@jest/environment": {
@@ -628,10 +628,10 @@
       "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "jest-mock": "24.9.0"
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0"
       }
     },
     "@jest/fake-timers": {
@@ -640,9 +640,9 @@
       "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-mock": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0"
       }
     },
     "@jest/reporters": {
@@ -651,27 +651,27 @@
       "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "glob": "7.1.4",
-        "istanbul-lib-coverage": "2.0.5",
-        "istanbul-lib-instrument": "3.3.0",
-        "istanbul-lib-report": "2.0.8",
-        "istanbul-lib-source-maps": "3.0.6",
-        "istanbul-reports": "2.2.6",
-        "jest-haste-map": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-worker": "24.9.0",
-        "node-notifier": "5.4.3",
-        "slash": "2.0.0",
-        "source-map": "0.6.1",
-        "string-length": "2.0.0"
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "istanbul-lib-coverage": "^2.0.2",
+        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.1",
+        "istanbul-reports": "^2.2.6",
+        "jest-haste-map": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.6.0",
+        "node-notifier": "^5.4.2",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^2.0.0"
       }
     },
     "@jest/source-map": {
@@ -680,9 +680,9 @@
       "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
       "dev": true,
       "requires": {
-        "callsites": "3.1.0",
-        "graceful-fs": "4.2.1",
-        "source-map": "0.6.1"
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.1.15",
+        "source-map": "^0.6.0"
       }
     },
     "@jest/test-result": {
@@ -691,9 +691,9 @@
       "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
       "dev": true,
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/istanbul-lib-coverage": "2.0.1"
+        "@jest/console": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/istanbul-lib-coverage": "^2.0.0"
       }
     },
     "@jest/test-sequencer": {
@@ -702,10 +702,10 @@
       "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-runner": "24.9.0",
-        "jest-runtime": "24.9.0"
+        "@jest/test-result": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0"
       }
     },
     "@jest/transform": {
@@ -714,21 +714,21 @@
       "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.5.5",
-        "@jest/types": "24.9.0",
-        "babel-plugin-istanbul": "5.2.0",
-        "chalk": "2.4.2",
-        "convert-source-map": "1.6.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "graceful-fs": "4.2.1",
-        "jest-haste-map": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-util": "24.9.0",
-        "micromatch": "3.1.10",
-        "pirates": "4.0.1",
-        "realpath-native": "1.1.0",
-        "slash": "2.0.0",
-        "source-map": "0.6.1",
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^24.9.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.15",
+        "jest-haste-map": "^24.9.0",
+        "jest-regex-util": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "pirates": "^4.0.1",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.1",
         "write-file-atomic": "2.4.1"
       }
     },
@@ -738,9 +738,9 @@
       "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-coverage": "2.0.1",
-        "@types/istanbul-reports": "1.1.1",
-        "@types/yargs": "13.0.2"
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
       }
     },
     "@marionebl/sander": {
@@ -749,9 +749,9 @@
       "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.1",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.7.1"
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
       }
     },
     "@nodelib/fs.scandir": {
@@ -761,7 +761,7 @@
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.3",
-        "run-parallel": "1.1.9"
+        "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
@@ -777,7 +777,7 @@
       "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
-        "fastq": "1.6.0"
+        "fastq": "^1.6.0"
       }
     },
     "@octokit/endpoint": {
@@ -786,9 +786,9 @@
       "integrity": "sha512-TXYS6zXeBImNB9BVj+LneMDqXX+H0exkOpyXobvp92O3B1348QsKnNioISFKgOMsb3ibZvQGwCdpiwQd3KAjIA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "1.1.0",
-        "is-plain-object": "3.0.0",
-        "universal-user-agent": "4.0.0"
+        "@octokit/types": "^1.0.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^4.0.0"
       },
       "dependencies": {
         "is-plain-object": {
@@ -797,7 +797,7 @@
           "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
           "dev": true,
           "requires": {
-            "isobject": "4.0.0"
+            "isobject": "^4.0.0"
           }
         },
         "isobject": {
@@ -814,14 +814,14 @@
       "integrity": "sha512-mMIeNrtYyNEIYNsKivDyUAukBkw0M5ckyJX56xoFRXSasDPCloIXaQOnaKNopzQ8dIOvpdq1ma8gmrS+h6O2OQ==",
       "dev": true,
       "requires": {
-        "@octokit/endpoint": "5.5.0",
-        "@octokit/request-error": "1.0.4",
-        "@octokit/types": "1.1.0",
-        "deprecation": "2.3.1",
-        "is-plain-object": "3.0.0",
-        "node-fetch": "2.6.0",
-        "once": "1.4.0",
-        "universal-user-agent": "4.0.0"
+        "@octokit/endpoint": "^5.5.0",
+        "@octokit/request-error": "^1.0.1",
+        "@octokit/types": "^1.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
       },
       "dependencies": {
         "is-plain-object": {
@@ -830,7 +830,7 @@
           "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
           "dev": true,
           "requires": {
-            "isobject": "4.0.0"
+            "isobject": "^4.0.0"
           }
         },
         "isobject": {
@@ -847,8 +847,8 @@
       "integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
       "dev": true,
       "requires": {
-        "deprecation": "2.3.1",
-        "once": "1.4.0"
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
       }
     },
     "@octokit/rest": {
@@ -857,18 +857,18 @@
       "integrity": "sha512-JUoS12cdktf1fv86rgrjC/RvYLuL+o7p57W7zX1x7ANFJ7OvdV8emvUNkFlcidEaOkYrxK3SoWgQFt3FhNmabA==",
       "dev": true,
       "requires": {
-        "@octokit/request": "5.3.0",
-        "@octokit/request-error": "1.0.4",
-        "atob-lite": "2.0.0",
-        "before-after-hook": "2.1.0",
-        "btoa-lite": "1.0.0",
-        "deprecation": "2.3.1",
-        "lodash.get": "4.4.2",
-        "lodash.set": "4.3.2",
-        "lodash.uniq": "4.5.0",
-        "octokit-pagination-methods": "1.1.0",
-        "once": "1.4.0",
-        "universal-user-agent": "4.0.0"
+        "@octokit/request": "^5.2.0",
+        "@octokit/request-error": "^1.0.2",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^2.0.0",
+        "btoa-lite": "^1.0.0",
+        "deprecation": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
       }
     },
     "@octokit/types": {
@@ -877,7 +877,7 @@
       "integrity": "sha512-t4ZD74UnNVMq6kZBDZceflRKK3q4o5PoCKMAGht0RK84W57tqonqKL3vCxJHtbGExdan9RwV8r7VJBZxIM1O7Q==",
       "dev": true,
       "requires": {
-        "@types/node": "12.12.3"
+        "@types/node": "^12.11.1"
       },
       "dependencies": {
         "@types/node": {
@@ -894,10 +894,10 @@
       "integrity": "sha512-/U44eK5qL2olevbEi+GrJxq1lNGUABChqK58A3SkiDsZS6AoGO8CJHQ7OG0zx+spxwkY4TevZ85Whz/hYyO+5w==",
       "dev": true,
       "requires": {
-        "@semantic-release/error": "2.2.0",
-        "aggregate-error": "3.0.1",
-        "fs-extra": "8.1.0",
-        "lodash": "4.17.15"
+        "@semantic-release/error": "^2.1.0",
+        "aggregate-error": "^3.0.0",
+        "fs-extra": "^8.0.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "fs-extra": {
@@ -906,9 +906,9 @@
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.1",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         }
       }
@@ -919,12 +919,12 @@
       "integrity": "sha512-TezpOODuMcdDuGcGsI2QRqkH3sT7ffhsxid9J8OyspXDe8E4tshekJESJ6Pq8jTrggluKd3tCK26Vsyu6SkeSg==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "5.0.5",
-        "conventional-commits-filter": "2.0.2",
-        "conventional-commits-parser": "3.0.5",
-        "debug": "4.1.1",
-        "import-from": "3.0.0",
-        "lodash": "4.17.15"
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.0",
+        "debug": "^4.0.0",
+        "import-from": "^3.0.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "conventional-changelog-angular": {
@@ -933,8 +933,8 @@
           "integrity": "sha512-RrkdWnL/TVyWV1ayWmSsrWorsTDqjL/VwG5ZSEneBQrd65ONcfeA1cW7FLtNweQyMiKOyriCMTKRSlk18DjTrw==",
           "dev": true,
           "requires": {
-            "compare-func": "1.3.2",
-            "q": "1.5.1"
+            "compare-func": "^1.3.1",
+            "q": "^1.5.1"
           }
         },
         "conventional-commits-parser": {
@@ -943,13 +943,13 @@
           "integrity": "sha512-qVz9+5JwdJzsbt7JbJ6P7NOXBGt8CyLFJYSjKAuPSgO+5UGfcsbk9EMR+lI8Unlvx6qwIc2YDJlrGIfay2ehNA==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.5",
-            "is-text-path": "2.0.0",
-            "lodash": "4.17.15",
-            "meow": "4.0.1",
-            "split2": "2.2.0",
-            "through2": "3.0.1",
-            "trim-off-newlines": "1.0.1"
+            "JSONStream": "^1.0.4",
+            "is-text-path": "^2.0.0",
+            "lodash": "^4.2.1",
+            "meow": "^4.0.0",
+            "split2": "^2.0.0",
+            "through2": "^3.0.0",
+            "trim-off-newlines": "^1.0.0"
           }
         },
         "debug": {
@@ -958,7 +958,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "find-up": {
@@ -967,7 +967,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "import-from": {
@@ -976,7 +976,7 @@
           "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
           "dev": true,
           "requires": {
-            "resolve-from": "5.0.0"
+            "resolve-from": "^5.0.0"
           }
         },
         "is-text-path": {
@@ -985,7 +985,7 @@
           "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
           "dev": true,
           "requires": {
-            "text-extensions": "2.0.0"
+            "text-extensions": "^2.0.0"
           }
         },
         "locate-path": {
@@ -994,8 +994,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "meow": {
@@ -1004,15 +1004,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.5.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "ms": {
@@ -1027,7 +1027,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -1036,7 +1036,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -1051,8 +1051,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "resolve-from": {
@@ -1073,7 +1073,7 @@
           "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "2 || 3"
           }
         }
       }
@@ -1090,16 +1090,16 @@
       "integrity": "sha512-xtNXhdWW92VCG4EumZ/Ijj44Yezaau9pQ39KB4q3l17vyu55MwPzQjlhSfysPshwosmVkzp6LhvYIg9+xUL07A==",
       "dev": true,
       "requires": {
-        "@semantic-release/error": "2.2.0",
-        "aggregate-error": "3.0.1",
-        "debug": "4.1.1",
-        "dir-glob": "3.0.1",
-        "execa": "3.2.0",
-        "fs-extra": "8.1.0",
-        "globby": "10.0.1",
-        "lodash": "4.17.15",
-        "micromatch": "4.0.2",
-        "p-reduce": "2.1.0"
+        "@semantic-release/error": "^2.1.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "execa": "^3.2.0",
+        "fs-extra": "^8.0.0",
+        "globby": "^10.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.0",
+        "p-reduce": "^2.0.0"
       },
       "dependencies": {
         "braces": {
@@ -1108,7 +1108,7 @@
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
-            "fill-range": "7.0.1"
+            "fill-range": "^7.0.1"
           }
         },
         "cross-spawn": {
@@ -1117,9 +1117,9 @@
           "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.0",
-            "shebang-command": "2.0.0",
-            "which": "2.0.1"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "debug": {
@@ -1128,7 +1128,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "execa": {
@@ -1137,16 +1137,16 @@
           "integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
           "dev": true,
           "requires": {
-            "cross-spawn": "7.0.1",
-            "get-stream": "5.1.0",
-            "human-signals": "1.1.1",
-            "is-stream": "2.0.0",
-            "merge-stream": "2.0.0",
-            "npm-run-path": "4.0.0",
-            "onetime": "5.1.0",
-            "p-finally": "2.0.1",
-            "signal-exit": "3.0.2",
-            "strip-final-newline": "2.0.0"
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "fill-range": {
@@ -1155,7 +1155,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "5.0.1"
+            "to-regex-range": "^5.0.1"
           }
         },
         "fs-extra": {
@@ -1164,9 +1164,9 @@
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.1",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "get-stream": {
@@ -1175,7 +1175,7 @@
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "is-number": {
@@ -1202,8 +1202,8 @@
           "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "dev": true,
           "requires": {
-            "braces": "3.0.2",
-            "picomatch": "2.1.0"
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
           }
         },
         "ms": {
@@ -1218,7 +1218,7 @@
           "integrity": "sha512-8eyAOAH+bYXFPSnNnKr3J+yoybe8O87Is5rtAQ8qRczJz1ajcsjg8l2oZqP+Ppx15Ii3S1vUTjQN2h4YO2tWWQ==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.0"
+            "path-key": "^3.0.0"
           }
         },
         "p-finally": {
@@ -1245,7 +1245,7 @@
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
-            "shebang-regex": "3.0.0"
+            "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
@@ -1260,7 +1260,7 @@
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
-            "is-number": "7.0.0"
+            "is-number": "^7.0.0"
           }
         },
         "which": {
@@ -1269,7 +1269,7 @@
           "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -1280,22 +1280,22 @@
       "integrity": "sha512-Wo9OIULMRydbq+HpFh9yiLvra1XyEULPro9Tp4T5MQJ0WZyAQ3YQm74IdT8Pe/UmVDq2nfpT1oHrWkwOc4loHg==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "16.34.1",
-        "@semantic-release/error": "2.2.0",
-        "aggregate-error": "3.0.1",
-        "bottleneck": "2.19.5",
-        "debug": "4.1.1",
-        "dir-glob": "3.0.1",
-        "fs-extra": "8.1.0",
-        "globby": "10.0.1",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "3.0.1",
-        "issue-parser": "5.0.0",
-        "lodash": "4.17.15",
-        "mime": "2.4.4",
-        "p-filter": "2.1.0",
-        "p-retry": "4.2.0",
-        "url-join": "4.0.1"
+        "@octokit/rest": "^16.27.0",
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "bottleneck": "^2.18.1",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "fs-extra": "^8.0.0",
+        "globby": "^10.0.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^3.0.0",
+        "issue-parser": "^5.0.0",
+        "lodash": "^4.17.4",
+        "mime": "^2.4.3",
+        "p-filter": "^2.0.0",
+        "p-retry": "^4.0.0",
+        "url-join": "^4.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1304,7 +1304,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "fs-extra": {
@@ -1313,9 +1313,9 @@
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.1",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "https-proxy-agent": {
@@ -1324,8 +1324,8 @@
           "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
           "dev": true,
           "requires": {
-            "agent-base": "4.3.0",
-            "debug": "3.2.6"
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
           },
           "dependencies": {
             "debug": {
@@ -1334,7 +1334,7 @@
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "requires": {
-                "ms": "2.1.2"
+                "ms": "^2.1.1"
               }
             }
           }
@@ -1353,18 +1353,18 @@
       "integrity": "sha512-4uE4pYvf5XEWqJPTLCrrmp5zu9XnnLqDjsn+2yrpMICNCpTq3M5g9OD7hwQoolg5v373t2ZnNgdcjsz+lqU0aA==",
       "dev": true,
       "requires": {
-        "@semantic-release/error": "2.2.0",
-        "aggregate-error": "3.0.1",
-        "execa": "3.2.0",
-        "fs-extra": "8.1.0",
-        "lodash": "4.17.15",
-        "nerf-dart": "1.0.0",
-        "normalize-url": "4.5.0",
-        "npm": "6.12.1",
-        "rc": "1.2.8",
-        "read-pkg": "5.2.0",
-        "registry-auth-token": "4.0.0",
-        "tempy": "0.3.0"
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "execa": "^3.2.0",
+        "fs-extra": "^8.0.0",
+        "lodash": "^4.17.15",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^4.0.0",
+        "npm": "^6.10.3",
+        "rc": "^1.2.8",
+        "read-pkg": "^5.0.0",
+        "registry-auth-token": "^4.0.0",
+        "tempy": "^0.3.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -1373,9 +1373,9 @@
           "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.0",
-            "shebang-command": "2.0.0",
-            "which": "2.0.1"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "execa": {
@@ -1384,16 +1384,16 @@
           "integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
           "dev": true,
           "requires": {
-            "cross-spawn": "7.0.1",
-            "get-stream": "5.1.0",
-            "human-signals": "1.1.1",
-            "is-stream": "2.0.0",
-            "merge-stream": "2.0.0",
-            "npm-run-path": "4.0.0",
-            "onetime": "5.1.0",
-            "p-finally": "2.0.1",
-            "signal-exit": "3.0.2",
-            "strip-final-newline": "2.0.0"
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "fs-extra": {
@@ -1402,9 +1402,9 @@
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.1",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "get-stream": {
@@ -1413,7 +1413,7 @@
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "is-stream": {
@@ -1440,7 +1440,7 @@
           "integrity": "sha512-8eyAOAH+bYXFPSnNnKr3J+yoybe8O87Is5rtAQ8qRczJz1ajcsjg8l2oZqP+Ppx15Ii3S1vUTjQN2h4YO2tWWQ==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.0"
+            "path-key": "^3.0.0"
           }
         },
         "p-finally": {
@@ -1455,10 +1455,10 @@
           "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "7.5.5",
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2",
-            "lines-and-columns": "1.1.6"
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
           }
         },
         "path-key": {
@@ -1473,10 +1473,10 @@
           "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
           "dev": true,
           "requires": {
-            "@types/normalize-package-data": "2.4.0",
-            "normalize-package-data": "2.5.0",
-            "parse-json": "5.0.0",
-            "type-fest": "0.6.0"
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
           }
         },
         "shebang-command": {
@@ -1485,7 +1485,7 @@
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
-            "shebang-regex": "3.0.0"
+            "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
@@ -1500,7 +1500,7 @@
           "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -1511,16 +1511,16 @@
       "integrity": "sha512-vYGydZPoQqL4aJOsaqXTZIekRb3aa/OlxlEVUvyrWWlNGqmQ1T7NUOos9eoN5DBCEuk6PwDrxPbhzgswxcvprQ==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "5.0.5",
-        "conventional-changelog-writer": "4.0.9",
-        "conventional-commits-filter": "2.0.2",
-        "conventional-commits-parser": "3.0.5",
-        "debug": "4.1.1",
-        "get-stream": "5.1.0",
-        "import-from": "3.0.0",
-        "into-stream": "5.1.1",
-        "lodash": "4.17.15",
-        "read-pkg-up": "7.0.0"
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-changelog-writer": "^4.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.0",
+        "debug": "^4.0.0",
+        "get-stream": "^5.0.0",
+        "import-from": "^3.0.0",
+        "into-stream": "^5.0.0",
+        "lodash": "^4.17.4",
+        "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
         "conventional-changelog-angular": {
@@ -1529,8 +1529,8 @@
           "integrity": "sha512-RrkdWnL/TVyWV1ayWmSsrWorsTDqjL/VwG5ZSEneBQrd65ONcfeA1cW7FLtNweQyMiKOyriCMTKRSlk18DjTrw==",
           "dev": true,
           "requires": {
-            "compare-func": "1.3.2",
-            "q": "1.5.1"
+            "compare-func": "^1.3.1",
+            "q": "^1.5.1"
           }
         },
         "conventional-commits-parser": {
@@ -1539,13 +1539,13 @@
           "integrity": "sha512-qVz9+5JwdJzsbt7JbJ6P7NOXBGt8CyLFJYSjKAuPSgO+5UGfcsbk9EMR+lI8Unlvx6qwIc2YDJlrGIfay2ehNA==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.5",
-            "is-text-path": "2.0.0",
-            "lodash": "4.17.15",
-            "meow": "4.0.1",
-            "split2": "2.2.0",
-            "through2": "3.0.1",
-            "trim-off-newlines": "1.0.1"
+            "JSONStream": "^1.0.4",
+            "is-text-path": "^2.0.0",
+            "lodash": "^4.2.1",
+            "meow": "^4.0.0",
+            "split2": "^2.0.0",
+            "through2": "^3.0.0",
+            "trim-off-newlines": "^1.0.0"
           }
         },
         "debug": {
@@ -1554,7 +1554,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "find-up": {
@@ -1563,7 +1563,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "get-stream": {
@@ -1572,7 +1572,7 @@
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "import-from": {
@@ -1581,7 +1581,7 @@
           "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
           "dev": true,
           "requires": {
-            "resolve-from": "5.0.0"
+            "resolve-from": "^5.0.0"
           }
         },
         "is-text-path": {
@@ -1590,7 +1590,7 @@
           "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
           "dev": true,
           "requires": {
-            "text-extensions": "2.0.0"
+            "text-extensions": "^2.0.0"
           }
         },
         "locate-path": {
@@ -1599,8 +1599,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "meow": {
@@ -1609,15 +1609,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.5.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           },
           "dependencies": {
             "read-pkg-up": {
@@ -1626,8 +1626,8 @@
               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
               "dev": true,
               "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "3.0.0"
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
               }
             }
           }
@@ -1644,7 +1644,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -1653,7 +1653,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -1668,10 +1668,10 @@
           "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "7.5.5",
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2",
-            "lines-and-columns": "1.1.6"
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
           }
         },
         "read-pkg-up": {
@@ -1680,9 +1680,9 @@
           "integrity": "sha512-t2ODkS/vTTcRlKwZiZsaLGb5iwfx9Urp924aGzVyboU6+7Z2i6eGr/G1Z4mjvwLLQV3uFOBKobNRGM3ux2PD/w==",
           "dev": true,
           "requires": {
-            "find-up": "4.1.0",
-            "read-pkg": "5.2.0",
-            "type-fest": "0.8.1"
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
           },
           "dependencies": {
             "find-up": {
@@ -1691,8 +1691,8 @@
               "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
               "dev": true,
               "requires": {
-                "locate-path": "5.0.0",
-                "path-exists": "4.0.0"
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
               }
             },
             "locate-path": {
@@ -1701,7 +1701,7 @@
               "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
               "dev": true,
               "requires": {
-                "p-locate": "4.1.0"
+                "p-locate": "^4.1.0"
               }
             },
             "p-limit": {
@@ -1710,7 +1710,7 @@
               "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
               "dev": true,
               "requires": {
-                "p-try": "2.2.0"
+                "p-try": "^2.0.0"
               }
             },
             "p-locate": {
@@ -1719,7 +1719,7 @@
               "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
               "dev": true,
               "requires": {
-                "p-limit": "2.2.1"
+                "p-limit": "^2.2.0"
               }
             },
             "p-try": {
@@ -1740,10 +1740,10 @@
               "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
               "dev": true,
               "requires": {
-                "@types/normalize-package-data": "2.4.0",
-                "normalize-package-data": "2.5.0",
-                "parse-json": "5.0.0",
-                "type-fest": "0.6.0"
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
               },
               "dependencies": {
                 "type-fest": {
@@ -1774,7 +1774,7 @@
           "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "2 || 3"
           }
         },
         "type-fest": {
@@ -1791,11 +1791,11 @@
       "integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
       "dev": true,
       "requires": {
-        "@babel/parser": "7.5.5",
-        "@babel/types": "7.5.5",
-        "@types/babel__generator": "7.0.2",
-        "@types/babel__template": "7.0.2",
-        "@types/babel__traverse": "7.0.7"
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
       }
     },
     "@types/babel__generator": {
@@ -1804,7 +1804,7 @@
       "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
@@ -1813,8 +1813,8 @@
       "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
       "dev": true,
       "requires": {
-        "@babel/parser": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__traverse": {
@@ -1823,7 +1823,7 @@
       "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.3.0"
       }
     },
     "@types/estree": {
@@ -1844,9 +1844,9 @@
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
       "dev": true,
       "requires": {
-        "@types/events": "3.0.0",
-        "@types/minimatch": "3.0.3",
-        "@types/node": "12.7.1"
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -1861,7 +1861,7 @@
       "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-coverage": "2.0.1"
+        "@types/istanbul-lib-coverage": "*"
       }
     },
     "@types/istanbul-reports": {
@@ -1870,8 +1870,8 @@
       "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-coverage": "2.0.1",
-        "@types/istanbul-lib-report": "1.1.1"
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
       }
     },
     "@types/jest": {
@@ -1880,7 +1880,7 @@
       "integrity": "sha512-1cy3xkOAfSYn78dsBWy4M3h/QF/HeWPchNFDjysVtp3GHeTdSmtluNnELfCmfNRRHo0OWEcpf+NsEJQvwQfdqQ==",
       "dev": true,
       "requires": {
-        "@types/jest-diff": "20.0.1"
+        "@types/jest-diff": "*"
       }
     },
     "@types/jest-diff": {
@@ -1919,7 +1919,7 @@
       "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
       "dev": true,
       "requires": {
-        "@types/node": "12.7.1"
+        "@types/node": "*"
       }
     },
     "@types/retry": {
@@ -1946,7 +1946,7 @@
       "integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
       "dev": true,
       "requires": {
-        "@types/yargs-parser": "13.0.0"
+        "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
@@ -1961,8 +1961,8 @@
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abab": {
@@ -1989,8 +1989,8 @@
       "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
       "dev": true,
       "requires": {
-        "acorn": "6.3.0",
-        "acorn-walk": "6.2.0"
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -2019,7 +2019,7 @@
       "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "requires": {
-        "es6-promisify": "5.0.0"
+        "es6-promisify": "^5.0.0"
       },
       "dependencies": {
         "es6-promisify": {
@@ -2028,7 +2028,7 @@
           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "dev": true,
           "requires": {
-            "es6-promise": "4.2.8"
+            "es6-promise": "^4.0.3"
           }
         }
       }
@@ -2039,8 +2039,8 @@
       "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
       "dev": true,
       "requires": {
-        "clean-stack": "2.2.0",
-        "indent-string": "4.0.0"
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
       },
       "dependencies": {
         "indent-string": {
@@ -2057,10 +2057,10 @@
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "alphanum-sort": {
@@ -2087,7 +2087,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "ansicolors": {
@@ -2102,8 +2102,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       }
     },
     "aproba": {
@@ -2118,8 +2118,8 @@
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -2128,7 +2128,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "argv": {
@@ -2209,7 +2209,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
@@ -2266,13 +2266,13 @@
       "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.6.6",
-        "caniuse-lite": "1.0.30000989",
-        "chalk": "2.4.2",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "4.0.2"
+        "browserslist": "^4.6.3",
+        "caniuse-lite": "^1.0.30000980",
+        "chalk": "^2.4.2",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.17",
+        "postcss-value-parser": "^4.0.0"
       }
     },
     "aws-sign2": {
@@ -2293,13 +2293,13 @@
       "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
       "dev": true,
       "requires": {
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/babel__core": "7.1.2",
-        "babel-plugin-istanbul": "5.2.0",
-        "babel-preset-jest": "24.9.0",
-        "chalk": "2.4.2",
-        "slash": "2.0.0"
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/babel__core": "^7.1.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "babel-preset-jest": "^24.9.0",
+        "chalk": "^2.4.2",
+        "slash": "^2.0.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -2308,10 +2308,10 @@
       "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "find-up": "3.0.0",
-        "istanbul-lib-instrument": "3.3.0",
-        "test-exclude": "5.2.3"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "find-up": "^3.0.0",
+        "istanbul-lib-instrument": "^3.3.0",
+        "test-exclude": "^5.2.3"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -2320,7 +2320,7 @@
       "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
       "dev": true,
       "requires": {
-        "@types/babel__traverse": "7.0.7"
+        "@types/babel__traverse": "^7.0.6"
       }
     },
     "babel-plugin-transform-async-to-promises": {
@@ -2335,9 +2335,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.6.9",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -2354,8 +2354,8 @@
       "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
       "dev": true,
       "requires": {
-        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
-        "babel-plugin-jest-hoist": "24.9.0"
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "babel-plugin-jest-hoist": "^24.9.0"
       }
     },
     "babel-runtime": {
@@ -2364,8 +2364,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.6.9",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -2394,13 +2394,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.3.0",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.2",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2409,7 +2409,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2418,7 +2418,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2427,7 +2427,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2436,9 +2436,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -2449,7 +2449,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "before-after-hook": {
@@ -2470,8 +2470,8 @@
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "boolbase": {
@@ -2492,7 +2492,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2502,16 +2502,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.3",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2520,7 +2520,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -2531,8 +2531,8 @@
       "integrity": "sha512-bBIdd8uUGxKGldAVykxOqPegl+HlIm4FpXJamwWw5x77WCE8jO7AhXFE1YXOhOB28gS+2pTQete0FqRE6U5hQQ==",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "iltorb": "2.4.3"
+        "duplexer": "^0.1.1",
+        "iltorb": "^2.0.5"
       }
     },
     "browser-process-hrtime": {
@@ -2564,9 +2564,9 @@
       "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000989",
-        "electron-to-chromium": "1.3.219",
-        "node-releases": "1.1.26"
+        "caniuse-lite": "^1.0.30000984",
+        "electron-to-chromium": "^1.3.191",
+        "node-releases": "^1.1.25"
       }
     },
     "bs-logger": {
@@ -2575,7 +2575,7 @@
       "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
       "dev": true,
       "requires": {
-        "fast-json-stable-stringify": "2.0.0"
+        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -2584,7 +2584,7 @@
       "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
       "dev": true,
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "btoa-lite": {
@@ -2599,14 +2599,14 @@
       "integrity": "sha512-IoGZzrUTY5fKXVkgGHw3QeXFMUNBFv+9l8a4QJKG1JhG3nCMHTdEX1DCOg8568E2Q9qvAQIiSokv6Jsgx8p2cA==",
       "dev": true,
       "requires": {
-        "acorn": "6.2.1",
-        "acorn-dynamic-import": "4.0.0",
-        "acorn-jsx": "5.0.1",
-        "chalk": "2.4.2",
-        "magic-string": "0.25.3",
-        "minimist": "1.2.0",
-        "os-homedir": "2.0.0",
-        "regexpu-core": "4.5.4"
+        "acorn": "^6.1.1",
+        "acorn-dynamic-import": "^4.0.0",
+        "acorn-jsx": "^5.0.1",
+        "chalk": "^2.4.2",
+        "magic-string": "^0.25.3",
+        "minimist": "^1.2.0",
+        "os-homedir": "^2.0.0",
+        "regexpu-core": "^4.5.4"
       },
       "dependencies": {
         "acorn": {
@@ -2629,8 +2629,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2663,15 +2663,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.3.0",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.1",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.1",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "caller-callsite": {
@@ -2680,7 +2680,7 @@
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0"
+        "callsites": "^2.0.0"
       },
       "dependencies": {
         "callsites": {
@@ -2697,7 +2697,7 @@
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
-        "caller-callsite": "2.0.0"
+        "caller-callsite": "^2.0.0"
       }
     },
     "callsites": {
@@ -2718,9 +2718,9 @@
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "map-obj": "2.0.0",
-        "quick-lru": "1.1.0"
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2737,10 +2737,10 @@
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.6.6",
-        "caniuse-lite": "1.0.30000989",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
       }
     },
     "caniuse-db": {
@@ -2761,7 +2761,7 @@
       "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
       "dev": true,
       "requires": {
-        "rsvp": "4.8.5"
+        "rsvp": "^4.8.4"
       }
     },
     "cardinal": {
@@ -2770,8 +2770,8 @@
       "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
       "dev": true,
       "requires": {
-        "ansicolors": "0.3.2",
-        "redeyed": "2.1.1"
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
       }
     },
     "caseless": {
@@ -2786,9 +2786,9 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chownr": {
@@ -2809,7 +2809,7 @@
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.1.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2830,11 +2830,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -2843,7 +2843,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2860,10 +2860,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2872,7 +2872,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -2906,9 +2906,9 @@
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0",
-        "wrap-ansi": "5.1.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
         "string-width": {
@@ -2917,9 +2917,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         }
       }
@@ -2942,9 +2942,9 @@
       "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
       "dev": true,
       "requires": {
-        "@types/q": "1.5.2",
-        "chalk": "2.4.2",
-        "q": "1.5.1"
+        "@types/q": "^1.5.1",
+        "chalk": "^2.4.1",
+        "q": "^1.1.2"
       }
     },
     "code-point-at": {
@@ -2959,11 +2959,11 @@
       "integrity": "sha512-IUJB6WG47nWK7o50etF8jBadxdMw7DmoQg05yIljstXFBGB6clOZsIj6iD4P82T2YaIU3qq+FFu8K9pxgkCJDQ==",
       "dev": true,
       "requires": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.3",
-        "js-yaml": "3.13.1",
-        "teeny-request": "3.11.3",
-        "urlgrey": "0.4.4"
+        "argv": "^0.0.2",
+        "ignore-walk": "^3.0.1",
+        "js-yaml": "^3.13.1",
+        "teeny-request": "^3.11.3",
+        "urlgrey": "^0.4.4"
       }
     },
     "collection-visit": {
@@ -2972,8 +2972,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color": {
@@ -2982,8 +2982,8 @@
       "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3",
-        "color-string": "1.5.3"
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
@@ -3007,8 +3007,8 @@
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3",
-        "simple-swizzle": "0.2.2"
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "colormin": {
@@ -3017,9 +3017,9 @@
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "dev": true,
       "requires": {
-        "color": "0.11.4",
+        "color": "^0.11.0",
         "css-color-names": "0.0.4",
-        "has": "1.0.3"
+        "has": "^1.0.1"
       },
       "dependencies": {
         "color": {
@@ -3028,9 +3028,9 @@
           "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
           "dev": true,
           "requires": {
-            "clone": "1.0.4",
-            "color-convert": "1.9.3",
-            "color-string": "0.3.0"
+            "clone": "^1.0.2",
+            "color-convert": "^1.3.0",
+            "color-string": "^0.3.0"
           }
         },
         "color-string": {
@@ -3039,7 +3039,7 @@
           "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "^1.0.0"
           }
         }
       }
@@ -3056,7 +3056,7 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -3071,8 +3071,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "1.0.0",
-        "dot-prop": "3.0.0"
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
       },
       "dependencies": {
         "dot-prop": {
@@ -3081,7 +3081,7 @@
           "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
           "dev": true,
           "requires": {
-            "is-obj": "1.0.1"
+            "is-obj": "^1.0.0"
           }
         }
       }
@@ -3104,7 +3104,7 @@
       "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
       "dev": true,
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "^0.6.1"
       }
     },
     "console-control-strings": {
@@ -3119,8 +3119,8 @@
       "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-writer": {
@@ -3129,16 +3129,16 @@
       "integrity": "sha512-2Y3QfiAM37WvDMjkVNaRtZgxVzWKj73HE61YQ/95T53yle+CRwTVSl6Gbv/lWVKXeZcM5af9n9TDVf0k7Xh+cw==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "conventional-commits-filter": "2.0.2",
-        "dateformat": "3.0.3",
-        "handlebars": "4.5.1",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.15",
-        "meow": "4.0.1",
-        "semver": "6.3.0",
-        "split": "1.0.1",
-        "through2": "3.0.1"
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^2.0.2",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.4.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "semver": "^6.0.0",
+        "split": "^1.0.0",
+        "through2": "^3.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -3147,7 +3147,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "handlebars": {
@@ -3156,10 +3156,10 @@
           "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
           "dev": true,
           "requires": {
-            "neo-async": "2.6.1",
-            "optimist": "0.6.1",
-            "source-map": "0.6.1",
-            "uglify-js": "3.6.0"
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
           }
         },
         "locate-path": {
@@ -3168,8 +3168,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "meow": {
@@ -3178,15 +3178,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.5.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "p-limit": {
@@ -3195,7 +3195,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -3204,7 +3204,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -3219,8 +3219,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "semver": {
@@ -3235,7 +3235,7 @@
           "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "2 || 3"
           }
         }
       }
@@ -3246,8 +3246,8 @@
       "integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
       "dev": true,
       "requires": {
-        "lodash.ismatch": "4.4.0",
-        "modify-values": "1.0.1"
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
@@ -3256,13 +3256,13 @@
       "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.5",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.15",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.5",
-        "trim-off-newlines": "1.0.1"
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -3271,7 +3271,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "locate-path": {
@@ -3280,8 +3280,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "meow": {
@@ -3290,15 +3290,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.5.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "p-limit": {
@@ -3307,7 +3307,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -3316,7 +3316,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -3331,8 +3331,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         }
       }
@@ -3343,7 +3343,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.1"
       }
     },
     "copy-descriptor": {
@@ -3370,10 +3370,10 @@
       "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "dev": true,
       "requires": {
-        "import-fresh": "2.0.0",
-        "is-directory": "0.3.1",
-        "js-yaml": "3.13.1",
-        "parse-json": "4.0.0"
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
       }
     },
     "cross-spawn": {
@@ -3382,11 +3382,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.7.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-random-string": {
@@ -3407,8 +3407,8 @@
       "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17",
-        "timsort": "0.3.0"
+        "postcss": "^7.0.1",
+        "timsort": "^0.3.0"
       }
     },
     "css-modules-loader-core": {
@@ -3443,11 +3443,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -3470,9 +3470,9 @@
           "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -3487,7 +3487,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -3496,7 +3496,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -3507,10 +3507,10 @@
       "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.3",
-        "domutils": "1.7.0",
-        "nth-check": "1.0.2"
+        "boolbase": "^1.0.0",
+        "css-what": "^2.1.2",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
       }
     },
     "css-select-base-adapter": {
@@ -3525,9 +3525,9 @@
       "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
       "dev": true,
       "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.2",
-        "regexpu-core": "1.0.0"
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
       },
       "dependencies": {
         "cssesc": {
@@ -3548,9 +3548,9 @@
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
-            "regenerate": "1.4.0",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         },
         "regjsgen": {
@@ -3565,7 +3565,7 @@
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
-            "jsesc": "0.5.0"
+            "jsesc": "~0.5.0"
           }
         }
       }
@@ -3577,7 +3577,7 @@
       "dev": true,
       "requires": {
         "mdn-data": "2.0.4",
-        "source-map": "0.5.7"
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "source-map": {
@@ -3612,10 +3612,10 @@
       "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "5.2.1",
-        "cssnano-preset-default": "4.0.7",
-        "is-resolvable": "1.1.0",
-        "postcss": "7.0.17"
+        "cosmiconfig": "^5.0.0",
+        "cssnano-preset-default": "^4.0.7",
+        "is-resolvable": "^1.0.0",
+        "postcss": "^7.0.0"
       }
     },
     "cssnano-preset-default": {
@@ -3624,36 +3624,36 @@
       "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
       "dev": true,
       "requires": {
-        "css-declaration-sorter": "4.0.1",
-        "cssnano-util-raw-cache": "4.0.1",
-        "postcss": "7.0.17",
-        "postcss-calc": "7.0.1",
-        "postcss-colormin": "4.0.3",
-        "postcss-convert-values": "4.0.1",
-        "postcss-discard-comments": "4.0.2",
-        "postcss-discard-duplicates": "4.0.2",
-        "postcss-discard-empty": "4.0.1",
-        "postcss-discard-overridden": "4.0.1",
-        "postcss-merge-longhand": "4.0.11",
-        "postcss-merge-rules": "4.0.3",
-        "postcss-minify-font-values": "4.0.2",
-        "postcss-minify-gradients": "4.0.2",
-        "postcss-minify-params": "4.0.2",
-        "postcss-minify-selectors": "4.0.2",
-        "postcss-normalize-charset": "4.0.1",
-        "postcss-normalize-display-values": "4.0.2",
-        "postcss-normalize-positions": "4.0.2",
-        "postcss-normalize-repeat-style": "4.0.2",
-        "postcss-normalize-string": "4.0.2",
-        "postcss-normalize-timing-functions": "4.0.2",
-        "postcss-normalize-unicode": "4.0.1",
-        "postcss-normalize-url": "4.0.1",
-        "postcss-normalize-whitespace": "4.0.2",
-        "postcss-ordered-values": "4.1.2",
-        "postcss-reduce-initial": "4.0.3",
-        "postcss-reduce-transforms": "4.0.2",
-        "postcss-svgo": "4.0.2",
-        "postcss-unique-selectors": "4.0.1"
+        "css-declaration-sorter": "^4.0.1",
+        "cssnano-util-raw-cache": "^4.0.1",
+        "postcss": "^7.0.0",
+        "postcss-calc": "^7.0.1",
+        "postcss-colormin": "^4.0.3",
+        "postcss-convert-values": "^4.0.1",
+        "postcss-discard-comments": "^4.0.2",
+        "postcss-discard-duplicates": "^4.0.2",
+        "postcss-discard-empty": "^4.0.1",
+        "postcss-discard-overridden": "^4.0.1",
+        "postcss-merge-longhand": "^4.0.11",
+        "postcss-merge-rules": "^4.0.3",
+        "postcss-minify-font-values": "^4.0.2",
+        "postcss-minify-gradients": "^4.0.2",
+        "postcss-minify-params": "^4.0.2",
+        "postcss-minify-selectors": "^4.0.2",
+        "postcss-normalize-charset": "^4.0.1",
+        "postcss-normalize-display-values": "^4.0.2",
+        "postcss-normalize-positions": "^4.0.2",
+        "postcss-normalize-repeat-style": "^4.0.2",
+        "postcss-normalize-string": "^4.0.2",
+        "postcss-normalize-timing-functions": "^4.0.2",
+        "postcss-normalize-unicode": "^4.0.1",
+        "postcss-normalize-url": "^4.0.1",
+        "postcss-normalize-whitespace": "^4.0.2",
+        "postcss-ordered-values": "^4.1.2",
+        "postcss-reduce-initial": "^4.0.3",
+        "postcss-reduce-transforms": "^4.0.2",
+        "postcss-svgo": "^4.0.2",
+        "postcss-unique-selectors": "^4.0.1"
       }
     },
     "cssnano-util-get-arguments": {
@@ -3674,7 +3674,7 @@
       "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "cssnano-util-same-parent": {
@@ -3698,8 +3698,8 @@
           "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
           "dev": true,
           "requires": {
-            "mdn-data": "1.1.4",
-            "source-map": "0.5.7"
+            "mdn-data": "~1.1.0",
+            "source-map": "^0.5.3"
           }
         },
         "mdn-data": {
@@ -3728,7 +3728,7 @@
       "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
       "dev": true,
       "requires": {
-        "cssom": "0.3.8"
+        "cssom": "0.3.x"
       }
     },
     "currently-unhandled": {
@@ -3737,7 +3737,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dargs": {
@@ -3746,7 +3746,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "dashdash": {
@@ -3755,7 +3755,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-urls": {
@@ -3764,9 +3764,9 @@
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "dev": true,
       "requires": {
-        "abab": "2.0.1",
-        "whatwg-mimetype": "2.3.0",
-        "whatwg-url": "7.0.0"
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.2.0",
+        "whatwg-url": "^7.0.0"
       },
       "dependencies": {
         "whatwg-url": {
@@ -3775,9 +3775,9 @@
           "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
           "dev": true,
           "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
           }
         }
       }
@@ -3809,8 +3809,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "map-obj": {
@@ -3833,7 +3833,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.1"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-extend": {
@@ -3854,7 +3854,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
@@ -3863,8 +3863,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3873,7 +3873,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3882,7 +3882,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3891,9 +3891,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -3952,7 +3952,7 @@
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "requires": {
-        "path-type": "4.0.0"
+        "path-type": "^4.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -3969,7 +3969,7 @@
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
-        "esutils": "1.1.6",
+        "esutils": "^1.1.6",
         "isarray": "0.0.1"
       },
       "dependencies": {
@@ -3993,8 +3993,8 @@
       "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
       "dev": true,
       "requires": {
-        "domelementtype": "2.0.1",
-        "entities": "2.0.0"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
       },
       "dependencies": {
         "domelementtype": {
@@ -4017,7 +4017,7 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "4.0.2"
+        "webidl-conversions": "^4.0.2"
       }
     },
     "domutils": {
@@ -4026,8 +4026,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.2.1",
-        "domelementtype": "1.3.1"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -4036,7 +4036,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer": {
@@ -4051,7 +4051,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.2"
       }
     },
     "ecc-jsbn": {
@@ -4060,8 +4060,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "electron-to-chromium": {
@@ -4088,7 +4088,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "entities": {
@@ -4103,8 +4103,8 @@
       "integrity": "sha512-Xtmr+ordf8POu3NcNzx3eOa2zHyfD4h3fPHX5fLklkWa86ck35n1c9oZmyUnVPUl9zHnpZWdWtCUBPSWEagjCQ==",
       "dev": true,
       "requires": {
-        "execa": "3.2.0",
-        "java-properties": "1.0.2"
+        "execa": "^3.2.0",
+        "java-properties": "^1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -4113,9 +4113,9 @@
           "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.0",
-            "shebang-command": "2.0.0",
-            "which": "2.0.1"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "execa": {
@@ -4124,16 +4124,16 @@
           "integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
           "dev": true,
           "requires": {
-            "cross-spawn": "7.0.1",
-            "get-stream": "5.1.0",
-            "human-signals": "1.1.1",
-            "is-stream": "2.0.0",
-            "merge-stream": "2.0.0",
-            "npm-run-path": "4.0.0",
-            "onetime": "5.1.0",
-            "p-finally": "2.0.1",
-            "signal-exit": "3.0.2",
-            "strip-final-newline": "2.0.0"
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "get-stream": {
@@ -4142,7 +4142,7 @@
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "is-stream": {
@@ -4163,7 +4163,7 @@
           "integrity": "sha512-8eyAOAH+bYXFPSnNnKr3J+yoybe8O87Is5rtAQ8qRczJz1ajcsjg8l2oZqP+Ppx15Ii3S1vUTjQN2h4YO2tWWQ==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.0"
+            "path-key": "^3.0.0"
           }
         },
         "p-finally": {
@@ -4184,7 +4184,7 @@
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
-            "shebang-regex": "3.0.0"
+            "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
@@ -4199,7 +4199,7 @@
           "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -4210,7 +4210,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -4219,12 +4219,12 @@
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.2.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4",
-        "object-keys": "1.1.1"
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
@@ -4233,9 +4233,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.2"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-promise": {
@@ -4262,11 +4262,11 @@
       "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.3.0",
-        "esutils": "2.0.3",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       }
     },
     "esprima": {
@@ -4305,13 +4305,13 @@
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "4.1.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exit": {
@@ -4326,13 +4326,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -4341,7 +4341,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -4350,7 +4350,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4361,7 +4361,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       },
       "dependencies": {
         "fill-range": {
@@ -4370,11 +4370,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.1.1",
-            "repeat-element": "1.1.3",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "is-number": {
@@ -4383,7 +4383,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isobject": {
@@ -4401,7 +4401,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4418,12 +4418,12 @@
       "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0",
-        "ansi-styles": "3.2.1",
-        "jest-get-type": "24.9.0",
-        "jest-matcher-utils": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-regex-util": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "ansi-styles": "^3.2.0",
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-regex-util": "^24.9.0"
       }
     },
     "extend": {
@@ -4438,8 +4438,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4448,7 +4448,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -4459,14 +4459,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -4475,7 +4475,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -4484,7 +4484,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -4493,7 +4493,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -4502,7 +4502,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -4511,9 +4511,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -4536,11 +4536,11 @@
       "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "2.0.3",
-        "@nodelib/fs.walk": "1.2.4",
-        "glob-parent": "5.1.0",
-        "merge2": "1.3.0",
-        "micromatch": "4.0.2"
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2"
       },
       "dependencies": {
         "braces": {
@@ -4549,7 +4549,7 @@
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
-            "fill-range": "7.0.1"
+            "fill-range": "^7.0.1"
           }
         },
         "fill-range": {
@@ -4558,7 +4558,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "5.0.1"
+            "to-regex-range": "^5.0.1"
           }
         },
         "glob-parent": {
@@ -4567,7 +4567,7 @@
           "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
           "dev": true,
           "requires": {
-            "is-glob": "4.0.1"
+            "is-glob": "^4.0.1"
           }
         },
         "is-extglob": {
@@ -4582,7 +4582,7 @@
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
@@ -4597,8 +4597,8 @@
           "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "dev": true,
           "requires": {
-            "braces": "3.0.2",
-            "picomatch": "2.1.0"
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
           }
         },
         "to-regex-range": {
@@ -4607,7 +4607,7 @@
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
-            "is-number": "7.0.0"
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -4636,7 +4636,7 @@
       "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
       "dev": true,
       "requires": {
-        "reusify": "1.0.4"
+        "reusify": "^1.0.0"
       }
     },
     "fb-watchman": {
@@ -4645,7 +4645,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "2.1.0"
+        "bser": "^2.0.0"
       }
     },
     "figures": {
@@ -4654,8 +4654,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "filename-regex": {
@@ -4676,10 +4676,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4688,7 +4688,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4699,7 +4699,7 @@
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
-        "locate-path": "3.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "find-versions": {
@@ -4708,8 +4708,8 @@
       "integrity": "sha512-NCTfNiVzeE/xL+roNDffGuRbrWI6atI18lTJ22vKp7rs2OhYzMK3W1dIdO2TUndH/QMcacM4d1uWwgcZcHK69Q==",
       "dev": true,
       "requires": {
-        "array-uniq": "2.1.0",
-        "semver-regex": "2.0.0"
+        "array-uniq": "^2.1.0",
+        "semver-regex": "^2.0.0"
       }
     },
     "flatten": {
@@ -4724,8 +4724,8 @@
       "integrity": "sha512-ypq/U3V+t9atYiOuSJd40tekCra03EHKoRsiK/wXGrsZimuum0kdwVY7Yv0HTaoXgHW1WiayomYd+Q3kkvPl9Q==",
       "dev": true,
       "requires": {
-        "babylon": "6.18.0",
-        "vlq": "0.2.3"
+        "babylon": "^6.15.0",
+        "vlq": "^0.2.1"
       }
     },
     "for-in": {
@@ -4740,7 +4740,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -4755,9 +4755,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.8",
-        "mime-types": "2.1.24"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -4766,7 +4766,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "from2": {
@@ -4775,8 +4775,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-constants": {
@@ -4791,9 +4791,9 @@
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.1",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -4809,8 +4809,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.14.0",
-        "node-pre-gyp": "0.12.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4822,7 +4822,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4836,21 +4837,23 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4863,17 +4866,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4887,7 +4893,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
@@ -4914,7 +4920,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -4929,14 +4935,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.3"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -4945,12 +4951,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -4965,7 +4971,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -4974,7 +4980,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -4983,14 +4989,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5002,8 +5009,9 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -5016,22 +5024,25 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -5040,13 +5051,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5063,9 +5075,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "4.1.1",
-            "iconv-lite": "0.4.24",
-            "sax": "1.2.4"
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5074,16 +5086,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.3.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.4.1",
-            "npmlog": "4.1.2",
-            "rc": "1.2.8",
-            "rimraf": "2.6.3",
-            "semver": "5.7.0",
-            "tar": "4.4.8"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -5092,8 +5104,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -5108,8 +5120,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.6"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -5118,16 +5130,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.5",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5139,8 +5152,9 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -5161,8 +5175,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -5183,10 +5197,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.6.0",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5203,13 +5217,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -5218,13 +5232,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.3"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5260,10 +5275,11 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -5272,15 +5288,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -5295,13 +5312,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.1.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.3.5",
-            "minizlib": "1.2.1",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -5316,18 +5333,20 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5343,14 +5362,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5365,7 +5384,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -5374,9 +5393,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -5385,7 +5404,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -5396,7 +5415,7 @@
       "integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
       "dev": true,
       "requires": {
-        "loader-utils": "0.2.17"
+        "loader-utils": "^0.2.16"
       }
     },
     "get-caller-file": {
@@ -5417,7 +5436,7 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
-        "pump": "3.0.0"
+        "pump": "^3.0.0"
       }
     },
     "get-value": {
@@ -5432,7 +5451,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "git-log-parser": {
@@ -5441,12 +5460,12 @@
       "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
       "dev": true,
       "requires": {
-        "argv-formatter": "1.0.0",
-        "spawn-error-forwarder": "1.0.0",
-        "split2": "1.0.0",
-        "stream-combiner2": "1.1.1",
-        "through2": "2.0.5",
-        "traverse": "0.6.6"
+        "argv-formatter": "~1.0.0",
+        "spawn-error-forwarder": "~1.0.0",
+        "split2": "~1.0.0",
+        "stream-combiner2": "~1.1.1",
+        "through2": "~2.0.0",
+        "traverse": "~0.6.6"
       },
       "dependencies": {
         "split2": {
@@ -5455,7 +5474,7 @@
           "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
           "dev": true,
           "requires": {
-            "through2": "2.0.5"
+            "through2": "~2.0.0"
           }
         }
       }
@@ -5466,11 +5485,11 @@
       "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
       "dev": true,
       "requires": {
-        "dargs": "4.1.0",
-        "lodash.template": "4.5.0",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.5"
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -5479,7 +5498,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "locate-path": {
@@ -5488,8 +5507,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "meow": {
@@ -5498,15 +5517,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.5.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "p-limit": {
@@ -5515,7 +5534,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -5524,7 +5543,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -5539,8 +5558,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         }
       }
@@ -5557,12 +5576,12 @@
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.4",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -5571,8 +5590,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -5581,7 +5600,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global-dirs": {
@@ -5590,7 +5609,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "globals": {
@@ -5611,14 +5630,14 @@
       "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
       "dev": true,
       "requires": {
-        "@types/glob": "7.1.1",
-        "array-union": "2.1.0",
-        "dir-glob": "3.0.1",
-        "fast-glob": "3.1.0",
-        "glob": "7.1.4",
-        "ignore": "5.1.4",
-        "merge2": "1.3.0",
-        "slash": "3.0.0"
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
       },
       "dependencies": {
         "slash": {
@@ -5653,8 +5672,8 @@
       "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "pify": "4.0.1"
+        "duplexer": "^0.1.1",
+        "pify": "^4.0.1"
       },
       "dependencies": {
         "pify": {
@@ -5671,10 +5690,10 @@
       "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
-        "neo-async": "2.6.1",
-        "optimist": "0.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.6.0"
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       }
     },
     "har-schema": {
@@ -5689,8 +5708,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "6.10.2",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -5699,7 +5718,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -5708,7 +5727,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5743,9 +5762,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -5754,8 +5773,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -5764,7 +5783,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5811,7 +5830,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.5"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "http-proxy-agent": {
@@ -5820,7 +5839,7 @@
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.3.0",
+        "agent-base": "4",
         "debug": "3.1.0"
       },
       "dependencies": {
@@ -5841,9 +5860,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.16.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -5852,8 +5871,8 @@
       "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.3.0",
-        "debug": "3.2.6"
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -5862,7 +5881,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -5885,7 +5904,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "icss-replace-symbols": {
@@ -5906,7 +5925,7 @@
       "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.4"
       }
     },
     "iltorb": {
@@ -5915,11 +5934,11 @@
       "integrity": "sha512-cr/kC07Cf9sW3TWH7yUxV2QkNjby4LMCsXGmxPCQs5x//QzTpF3GLPNY7L66G+DkNGaTRCgY+vYZ+dyAcuDOnQ==",
       "dev": true,
       "requires": {
-        "detect-libc": "1.0.3",
-        "nan": "2.14.0",
-        "npmlog": "4.1.2",
-        "prebuild-install": "5.3.0",
-        "which-pm-runs": "1.0.0"
+        "detect-libc": "^1.0.3",
+        "nan": "^2.13.2",
+        "npmlog": "^4.1.2",
+        "prebuild-install": "^5.3.0",
+        "which-pm-runs": "^1.0.0"
       }
     },
     "import-cwd": {
@@ -5928,7 +5947,7 @@
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
-        "import-from": "2.1.0"
+        "import-from": "^2.1.0"
       }
     },
     "import-fresh": {
@@ -5937,8 +5956,8 @@
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
-        "caller-path": "2.0.0",
-        "resolve-from": "3.0.0"
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
       }
     },
     "import-from": {
@@ -5947,7 +5966,7 @@
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "import-local": {
@@ -5956,8 +5975,8 @@
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "3.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -5984,8 +6003,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -6006,8 +6025,8 @@
       "integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
       "dev": true,
       "requires": {
-        "from2": "2.3.0",
-        "p-is-promise": "3.0.0"
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
       }
     },
     "invariant": {
@@ -6016,7 +6035,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "is-absolute-url": {
@@ -6031,7 +6050,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6040,7 +6059,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6069,7 +6088,7 @@
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "ci-info": "2.0.0"
+        "ci-info": "^2.0.0"
       }
     },
     "is-color-stop": {
@@ -6078,12 +6097,12 @@
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "requires": {
-        "css-color-names": "0.0.4",
-        "hex-color-regex": "1.1.0",
-        "hsl-regex": "1.0.0",
-        "hsla-regex": "1.0.0",
-        "rgb-regex": "1.0.1",
-        "rgba-regex": "1.0.0"
+        "css-color-names": "^0.0.4",
+        "hex-color-regex": "^1.1.0",
+        "hsl-regex": "^1.0.0",
+        "hsla-regex": "^1.0.0",
+        "rgb-regex": "^1.0.1",
+        "rgba-regex": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -6092,7 +6111,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6101,7 +6120,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6118,9 +6137,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6149,7 +6168,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -6182,7 +6201,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-module": {
@@ -6197,7 +6216,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6206,7 +6225,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6229,7 +6248,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -6250,7 +6269,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -6271,7 +6290,7 @@
       "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "dev": true,
       "requires": {
-        "html-comment-regex": "1.1.2"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-symbol": {
@@ -6280,7 +6299,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.0"
+        "has-symbols": "^1.0.0"
       }
     },
     "is-text-path": {
@@ -6289,7 +6308,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "1.9.0"
+        "text-extensions": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -6340,11 +6359,11 @@
       "integrity": "sha512-q/16W7EPHRL0FKVz9NU++TUsoygXGj6JOi88oulyAcQG+IEZ0T6teVdE+VLbe19OfL/tbV8Wi3Dfo0HedeHW0Q==",
       "dev": true,
       "requires": {
-        "lodash.capitalize": "4.2.1",
-        "lodash.escaperegexp": "4.1.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.uniqby": "4.7.0"
+        "lodash.capitalize": "^4.2.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.uniqby": "^4.7.0"
       }
     },
     "istanbul-lib-coverage": {
@@ -6359,13 +6378,13 @@
       "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.5.5",
-        "@babel/parser": "7.5.5",
-        "@babel/template": "7.4.4",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5",
-        "istanbul-lib-coverage": "2.0.5",
-        "semver": "6.3.0"
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
       },
       "dependencies": {
         "semver": {
@@ -6382,9 +6401,9 @@
       "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "2.0.5",
-        "make-dir": "2.1.0",
-        "supports-color": "6.1.0"
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "supports-color": {
@@ -6393,7 +6412,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -6404,11 +6423,11 @@
       "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1",
-        "istanbul-lib-coverage": "2.0.5",
-        "make-dir": "2.1.0",
-        "rimraf": "2.7.1",
-        "source-map": "0.6.1"
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "debug": {
@@ -6417,7 +6436,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -6434,7 +6453,7 @@
       "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
       "dev": true,
       "requires": {
-        "handlebars": "4.1.2"
+        "handlebars": "^4.1.2"
       }
     },
     "java-properties": {
@@ -6449,8 +6468,8 @@
       "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
       "dev": true,
       "requires": {
-        "import-local": "2.0.0",
-        "jest-cli": "24.9.0"
+        "import-local": "^2.0.0",
+        "jest-cli": "^24.9.0"
       },
       "dependencies": {
         "jest-cli": {
@@ -6459,19 +6478,19 @@
           "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
           "dev": true,
           "requires": {
-            "@jest/core": "24.9.0",
-            "@jest/test-result": "24.9.0",
-            "@jest/types": "24.9.0",
-            "chalk": "2.4.2",
-            "exit": "0.1.2",
-            "import-local": "2.0.0",
-            "is-ci": "2.0.0",
-            "jest-config": "24.9.0",
-            "jest-util": "24.9.0",
-            "jest-validate": "24.9.0",
-            "prompts": "2.2.1",
-            "realpath-native": "1.1.0",
-            "yargs": "13.3.0"
+            "@jest/core": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "import-local": "^2.0.0",
+            "is-ci": "^2.0.0",
+            "jest-config": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
+            "prompts": "^2.0.1",
+            "realpath-native": "^1.1.0",
+            "yargs": "^13.3.0"
           }
         }
       }
@@ -6482,9 +6501,9 @@
       "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0",
-        "execa": "1.0.0",
-        "throat": "4.1.0"
+        "@jest/types": "^24.9.0",
+        "execa": "^1.0.0",
+        "throat": "^4.0.0"
       }
     },
     "jest-config": {
@@ -6493,23 +6512,23 @@
       "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.5.5",
-        "@jest/test-sequencer": "24.9.0",
-        "@jest/types": "24.9.0",
-        "babel-jest": "24.9.0",
-        "chalk": "2.4.2",
-        "glob": "7.1.4",
-        "jest-environment-jsdom": "24.9.0",
-        "jest-environment-node": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "jest-jasmine2": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-validate": "24.9.0",
-        "micromatch": "3.1.10",
-        "pretty-format": "24.9.0",
-        "realpath-native": "1.1.0"
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "babel-jest": "^24.9.0",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^24.9.0",
+        "jest-environment-node": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "pretty-format": "^24.9.0",
+        "realpath-native": "^1.1.0"
       }
     },
     "jest-diff": {
@@ -6518,10 +6537,10 @@
       "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "diff-sequences": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "pretty-format": "24.9.0"
+        "chalk": "^2.0.1",
+        "diff-sequences": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-docblock": {
@@ -6530,7 +6549,7 @@
       "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
       "dev": true,
       "requires": {
-        "detect-newline": "2.1.0"
+        "detect-newline": "^2.1.0"
       }
     },
     "jest-each": {
@@ -6539,11 +6558,11 @@
       "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "jest-get-type": "24.9.0",
-        "jest-util": "24.9.0",
-        "pretty-format": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-environment-jsdom": {
@@ -6552,12 +6571,12 @@
       "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "24.9.0",
-        "@jest/fake-timers": "24.9.0",
-        "@jest/types": "24.9.0",
-        "jest-mock": "24.9.0",
-        "jest-util": "24.9.0",
-        "jsdom": "11.12.0"
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
@@ -6566,11 +6585,11 @@
       "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "24.9.0",
-        "@jest/fake-timers": "24.9.0",
-        "@jest/types": "24.9.0",
-        "jest-mock": "24.9.0",
-        "jest-util": "24.9.0"
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0"
       }
     },
     "jest-get-type": {
@@ -6585,18 +6604,18 @@
       "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0",
-        "anymatch": "2.0.0",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.2.9",
-        "graceful-fs": "4.2.1",
-        "invariant": "2.2.4",
-        "jest-serializer": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-worker": "24.9.0",
-        "micromatch": "3.1.10",
-        "sane": "4.1.0",
-        "walker": "1.0.7"
+        "@jest/types": "^24.9.0",
+        "anymatch": "^2.0.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.7",
+        "graceful-fs": "^4.1.15",
+        "invariant": "^2.2.4",
+        "jest-serializer": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7"
       }
     },
     "jest-jasmine2": {
@@ -6605,22 +6624,22 @@
       "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.5.5",
-        "@jest/environment": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "co": "4.6.0",
-        "expect": "24.9.0",
-        "is-generator-fn": "2.1.0",
-        "jest-each": "24.9.0",
-        "jest-matcher-utils": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-snapshot": "24.9.0",
-        "jest-util": "24.9.0",
-        "pretty-format": "24.9.0",
-        "throat": "4.1.0"
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^24.9.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0",
+        "throat": "^4.0.0"
       }
     },
     "jest-leak-detector": {
@@ -6629,8 +6648,8 @@
       "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
       "dev": true,
       "requires": {
-        "jest-get-type": "24.9.0",
-        "pretty-format": "24.9.0"
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-matcher-utils": {
@@ -6639,10 +6658,10 @@
       "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "jest-diff": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "pretty-format": "24.9.0"
+        "chalk": "^2.0.1",
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-message-util": {
@@ -6651,14 +6670,14 @@
       "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/stack-utils": "1.0.1",
-        "chalk": "2.4.2",
-        "micromatch": "3.1.10",
-        "slash": "2.0.0",
-        "stack-utils": "1.0.2"
+        "@babel/code-frame": "^7.0.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/stack-utils": "^1.0.1",
+        "chalk": "^2.0.1",
+        "micromatch": "^3.1.10",
+        "slash": "^2.0.0",
+        "stack-utils": "^1.0.1"
       }
     },
     "jest-mock": {
@@ -6667,7 +6686,7 @@
       "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0"
+        "@jest/types": "^24.9.0"
       }
     },
     "jest-pnp-resolver": {
@@ -6688,11 +6707,11 @@
       "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0",
-        "browser-resolve": "1.11.3",
-        "chalk": "2.4.2",
-        "jest-pnp-resolver": "1.2.1",
-        "realpath-native": "1.1.0"
+        "@jest/types": "^24.9.0",
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "jest-pnp-resolver": "^1.2.1",
+        "realpath-native": "^1.1.0"
       }
     },
     "jest-resolve-dependencies": {
@@ -6701,9 +6720,9 @@
       "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-snapshot": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-snapshot": "^24.9.0"
       }
     },
     "jest-runner": {
@@ -6712,25 +6731,25 @@
       "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
       "dev": true,
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/environment": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "graceful-fs": "4.2.1",
-        "jest-config": "24.9.0",
-        "jest-docblock": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-jasmine2": "24.9.0",
-        "jest-leak-detector": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-worker": "24.9.0",
-        "source-map-support": "0.5.13",
-        "throat": "4.1.0"
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.4.2",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.9.0",
+        "jest-docblock": "^24.3.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
+        "jest-leak-detector": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.6.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^4.0.0"
       }
     },
     "jest-runtime": {
@@ -6739,29 +6758,29 @@
       "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
       "dev": true,
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/environment": "24.9.0",
-        "@jest/source-map": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/yargs": "13.0.2",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "glob": "7.1.4",
-        "graceful-fs": "4.2.1",
-        "jest-config": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-mock": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-snapshot": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-validate": "24.9.0",
-        "realpath-native": "1.1.0",
-        "slash": "2.0.0",
-        "strip-bom": "3.0.0",
-        "yargs": "13.3.0"
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.9.0",
+        "@jest/source-map": "^24.3.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "strip-bom": "^3.0.0",
+        "yargs": "^13.3.0"
       }
     },
     "jest-serializer": {
@@ -6776,19 +6795,19 @@
       "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.5.5",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "expect": "24.9.0",
-        "jest-diff": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "jest-matcher-utils": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "24.9.0",
-        "semver": "6.3.0"
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "expect": "^24.9.0",
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^24.9.0",
+        "semver": "^6.2.0"
       },
       "dependencies": {
         "semver": {
@@ -6805,18 +6824,18 @@
       "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
       "dev": true,
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/fake-timers": "24.9.0",
-        "@jest/source-map": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "callsites": "3.1.0",
-        "chalk": "2.4.2",
-        "graceful-fs": "4.2.1",
-        "is-ci": "2.0.0",
-        "mkdirp": "0.5.1",
-        "slash": "2.0.0",
-        "source-map": "0.6.1"
+        "@jest/console": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/source-map": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "callsites": "^3.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.15",
+        "is-ci": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "jest-validate": {
@@ -6825,12 +6844,12 @@
       "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0",
-        "camelcase": "5.3.1",
-        "chalk": "2.4.2",
-        "jest-get-type": "24.9.0",
-        "leven": "3.1.0",
-        "pretty-format": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.9.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-watcher": {
@@ -6839,13 +6858,13 @@
       "integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/yargs": "13.0.2",
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.2",
-        "jest-util": "24.9.0",
-        "string-length": "2.0.0"
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "jest-util": "^24.9.0",
+        "string-length": "^2.0.0"
       }
     },
     "jest-worker": {
@@ -6854,8 +6873,8 @@
       "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
       "dev": true,
       "requires": {
-        "merge-stream": "2.0.0",
-        "supports-color": "6.1.0"
+        "merge-stream": "^2.0.0",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "merge-stream": {
@@ -6870,7 +6889,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -6893,8 +6912,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -6917,32 +6936,32 @@
       "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
       "dev": true,
       "requires": {
-        "abab": "2.0.1",
-        "acorn": "5.7.3",
-        "acorn-globals": "4.3.3",
-        "array-equal": "1.0.0",
-        "cssom": "0.3.8",
-        "cssstyle": "1.4.0",
-        "data-urls": "1.1.0",
-        "domexception": "1.0.1",
-        "escodegen": "1.12.0",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.3.0",
-        "nwsapi": "2.1.4",
+        "abab": "^2.0.0",
+        "acorn": "^5.5.3",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": "^1.0.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.9.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "nwsapi": "^2.0.7",
         "parse5": "4.0.0",
-        "pn": "1.1.0",
-        "request": "2.88.0",
-        "request-promise-native": "1.0.7",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.4",
-        "tough-cookie": "2.5.0",
-        "w3c-hr-time": "1.0.1",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.5",
-        "whatwg-mimetype": "2.3.0",
-        "whatwg-url": "6.5.0",
-        "ws": "5.2.2",
-        "xml-name-validator": "3.0.0"
+        "pn": "^1.1.0",
+        "request": "^2.87.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.4",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^5.2.0",
+        "xml-name-validator": "^3.0.0"
       }
     },
     "jsesc": {
@@ -6981,7 +7000,7 @@
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.2.0"
       }
     },
     "jsonfile": {
@@ -6990,7 +7009,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.1"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonparse": {
@@ -7041,8 +7060,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lines-and-columns": {
@@ -7057,10 +7076,10 @@
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.1",
-        "parse-json": "4.0.0",
-        "pify": "3.0.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "loader-utils": {
@@ -7069,10 +7088,10 @@
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1",
-        "object-assign": "4.1.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "json5": {
@@ -7089,8 +7108,8 @@
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
-        "p-locate": "3.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -7183,8 +7202,8 @@
       "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.2.0"
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -7193,7 +7212,7 @@
       "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "^3.0.0"
       }
     },
     "lodash.toarray": {
@@ -7220,7 +7239,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -7229,8 +7248,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -7239,7 +7258,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
-        "yallist": "3.1.1"
+        "yallist": "^3.0.2"
       }
     },
     "macos-release": {
@@ -7254,7 +7273,7 @@
       "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "1.4.6"
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -7263,8 +7282,8 @@
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "requires": {
-        "pify": "4.0.1",
-        "semver": "5.7.0"
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "pify": {
@@ -7287,7 +7306,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "map-cache": {
@@ -7308,7 +7327,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "marked": {
@@ -7323,12 +7342,12 @@
       "integrity": "sha512-+IUQJ5VlZoAFsM5MHNT7g3RHSkA3eETqhRCdXv4niUMAKHQ7lb1yvAcuGPmm4soxhmtX13u4Li6ZToXtvSEH+A==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "cardinal": "2.1.1",
-        "chalk": "2.4.2",
-        "cli-table": "0.3.1",
-        "node-emoji": "1.10.0",
-        "supports-hyperlinks": "1.0.1"
+        "ansi-escapes": "^3.1.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^2.4.1",
+        "cli-table": "^0.3.1",
+        "node-emoji": "^1.4.1",
+        "supports-hyperlinks": "^1.0.1"
       }
     },
     "math-expression-evaluator": {
@@ -7349,10 +7368,10 @@
       "integrity": "sha1-TTsiCQPZXu5+t6x/qGTnLcCaMWY=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "figures": "1.7.0",
-        "gzip-size": "3.0.0",
-        "pretty-bytes": "3.0.1"
+        "chalk": "^1.0.0",
+        "figures": "^1.0.1",
+        "gzip-size": "^3.0.0",
+        "pretty-bytes": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7373,11 +7392,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "gzip-size": {
@@ -7386,7 +7405,7 @@
           "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
           "dev": true,
           "requires": {
-            "duplexer": "0.1.1"
+            "duplexer": "^0.1.1"
           }
         },
         "pretty-bytes": {
@@ -7395,7 +7414,7 @@
           "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "strip-ansi": {
@@ -7404,7 +7423,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -7427,15 +7446,15 @@
       "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
       "dev": true,
       "requires": {
-        "camelcase-keys": "4.2.0",
-        "decamelize-keys": "1.1.0",
-        "loud-rejection": "1.6.0",
-        "minimist-options": "3.0.2",
-        "normalize-package-data": "2.5.0",
-        "read-pkg-up": "3.0.0",
-        "redent": "2.0.0",
-        "trim-newlines": "2.0.0",
-        "yargs-parser": "10.1.0"
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0",
+        "yargs-parser": "^10.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -7450,7 +7469,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "locate-path": {
@@ -7459,8 +7478,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -7469,7 +7488,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -7478,7 +7497,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -7493,8 +7512,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "yargs-parser": {
@@ -7503,7 +7522,7 @@
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -7514,7 +7533,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       }
     },
     "merge2": {
@@ -7529,39 +7548,39 @@
       "integrity": "sha512-Lt2f8OhC2y2uKyJ5zA8lEEiDsIAbk6yllBuoAWLIdYVIXYqOdN9mO3DI7VW7x/fw87gdnCLIJdVtpP6kaI99LA==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.5.5",
+        "@babel/core": "^7.2.2",
         "@babel/plugin-proposal-class-properties": "7.2.1",
-        "@babel/plugin-syntax-jsx": "7.2.0",
-        "@babel/polyfill": "7.4.4",
-        "asyncro": "3.0.0",
-        "autoprefixer": "9.6.1",
-        "babel-plugin-transform-async-to-promises": "0.8.14",
-        "brotli-size": "0.0.3",
-        "camelcase": "5.3.1",
-        "chalk": "2.4.2",
-        "cssnano": "4.1.10",
-        "es6-promisify": "6.0.1",
-        "gzip-size": "5.1.1",
-        "pretty-bytes": "5.3.0",
-        "rollup": "0.67.4",
-        "rollup-plugin-alias": "1.5.2",
-        "rollup-plugin-babel": "4.3.3",
-        "rollup-plugin-buble": "0.19.8",
-        "rollup-plugin-bundle-size": "1.0.3",
-        "rollup-plugin-commonjs": "9.3.4",
-        "rollup-plugin-es3": "1.1.0",
-        "rollup-plugin-flow": "1.1.1",
-        "rollup-plugin-json": "3.1.0",
-        "rollup-plugin-node-resolve": "4.2.4",
-        "rollup-plugin-postcss": "1.6.3",
-        "rollup-plugin-preserve-shebang": "0.1.6",
-        "rollup-plugin-sizes": "0.4.2",
-        "rollup-plugin-terser": "3.0.0",
-        "rollup-plugin-typescript2": "0.19.3",
-        "sade": "1.6.1",
-        "tiny-glob": "0.2.6",
-        "tslib": "1.10.0",
-        "typescript": "3.6.2"
+        "@babel/plugin-syntax-jsx": "^7.2.0",
+        "@babel/polyfill": "^7.0.0",
+        "asyncro": "^3.0.0",
+        "autoprefixer": "^9.0.0",
+        "babel-plugin-transform-async-to-promises": "^0.8.3",
+        "brotli-size": "^0.0.3",
+        "camelcase": "^5.0.0",
+        "chalk": "^2.4.0",
+        "cssnano": "^4.1.7",
+        "es6-promisify": "^6.0.1",
+        "gzip-size": "^5.0.0",
+        "pretty-bytes": "^5.1.0",
+        "rollup": "^0.67.3",
+        "rollup-plugin-alias": "^1.5.1",
+        "rollup-plugin-babel": "^4.1.0-0",
+        "rollup-plugin-buble": "^0.19.4",
+        "rollup-plugin-bundle-size": "^1.0.1",
+        "rollup-plugin-commonjs": "^9.0.0",
+        "rollup-plugin-es3": "^1.1.0",
+        "rollup-plugin-flow": "^1.1.1",
+        "rollup-plugin-json": "^3.1.0",
+        "rollup-plugin-node-resolve": "^4.0.0",
+        "rollup-plugin-postcss": "^1.6.1",
+        "rollup-plugin-preserve-shebang": "^0.1.6",
+        "rollup-plugin-sizes": "^0.4.2",
+        "rollup-plugin-terser": "^3.0.0",
+        "rollup-plugin-typescript2": "^0.19.0",
+        "sade": "^1.4.0",
+        "tiny-glob": "^0.2.6",
+        "tslib": "^1.9.0",
+        "typescript": ">=2.8.3"
       }
     },
     "micromatch": {
@@ -7570,19 +7589,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.13",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime": {
@@ -7624,7 +7643,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -7639,8 +7658,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "mixin-deep": {
@@ -7649,8 +7668,8 @@
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -7659,7 +7678,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -7717,17 +7736,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "napi-build-utils": {
@@ -7766,7 +7785,7 @@
       "integrity": "sha512-OT0WepUvYHXdki6DU8LWhEkuo3M44i2paWBYtH9qXtPb9YiKlYEKa5WUII20XEcOv7UJPzfB0kZfPZdW46zdkw==",
       "dev": true,
       "requires": {
-        "semver": "5.7.0"
+        "semver": "^5.4.1"
       }
     },
     "node-emoji": {
@@ -7775,7 +7794,7 @@
       "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
       "dev": true,
       "requires": {
-        "lodash.toarray": "4.4.0"
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-fetch": {
@@ -7802,11 +7821,11 @@
       "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "is-wsl": "1.1.0",
-        "semver": "5.7.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.1"
+        "growly": "^1.3.0",
+        "is-wsl": "^1.1.0",
+        "semver": "^5.5.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "node-releases": {
@@ -7815,7 +7834,7 @@
       "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
       "dev": true,
       "requires": {
-        "semver": "5.7.0"
+        "semver": "^5.3.0"
       }
     },
     "noop-logger": {
@@ -7830,10 +7849,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.8.4",
-        "resolve": "1.12.0",
-        "semver": "5.7.0",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -7842,7 +7861,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -7863,129 +7882,129 @@
       "integrity": "sha512-+pMvUpgSXVBythrv//64j4i6DaLLJ1O0y8kwjNgjAE7atBNGzX4rcOEWvmsuiei6J+mA38O0nUZ/P35GuCD/jg==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.5",
-        "abbrev": "1.1.1",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "2.0.0",
-        "archy": "1.0.0",
-        "bin-links": "1.1.3",
-        "bluebird": "3.5.5",
-        "byte-size": "5.0.1",
-        "cacache": "12.0.3",
-        "call-limit": "1.1.1",
-        "chownr": "1.1.3",
-        "ci-info": "2.0.0",
-        "cli-columns": "3.1.2",
-        "cli-table3": "0.5.1",
-        "cmd-shim": "3.0.3",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.12",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "detect-newline": "2.1.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "figgy-pudding": "3.5.1",
-        "find-npm-prefix": "1.0.2",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "gentle-fs": "2.2.1",
-        "glob": "7.1.4",
-        "graceful-fs": "4.2.3",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.8.5",
-        "iferr": "1.0.2",
-        "imurmurhash": "0.1.4",
-        "infer-owner": "1.0.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.4",
-        "ini": "1.3.5",
-        "init-package-json": "1.10.3",
-        "is-cidr": "3.0.0",
-        "json-parse-better-errors": "1.0.2",
-        "lazy-property": "1.0.0",
-        "libcipm": "4.0.7",
-        "libnpm": "3.0.1",
-        "libnpmaccess": "3.0.2",
-        "libnpmhook": "5.0.3",
-        "libnpmorg": "1.0.1",
-        "libnpmsearch": "2.0.2",
-        "libnpmteam": "1.0.2",
-        "libnpx": "10.2.0",
-        "lock-verify": "2.1.0",
-        "lockfile": "1.0.4",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "5.1.1",
-        "meant": "1.0.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "node-gyp": "5.0.5",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.5.0",
-        "npm-audit-report": "1.3.2",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.2",
-        "npm-lifecycle": "3.1.4",
-        "npm-package-arg": "6.1.1",
-        "npm-packlist": "1.4.6",
-        "npm-pick-manifest": "3.0.2",
-        "npm-profile": "4.0.2",
-        "npm-registry-fetch": "4.0.2",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.5.1",
-        "osenv": "0.1.5",
-        "pacote": "9.5.8",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "qrcode-terminal": "0.12.0",
-        "query-string": "6.8.2",
-        "qw": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.4",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.1.0",
-        "read-package-tree": "5.3.1",
-        "readable-stream": "3.4.0",
-        "readdir-scoped-modules": "1.1.0",
-        "request": "2.88.0",
-        "retry": "0.12.0",
-        "rimraf": "2.6.3",
-        "safe-buffer": "5.1.2",
-        "semver": "5.7.1",
-        "sha": "3.0.0",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "6.0.1",
-        "stringify-package": "1.0.1",
-        "tar": "4.4.13",
-        "text-table": "0.2.0",
-        "tiny-relative-date": "1.3.0",
+        "JSONStream": "^1.3.5",
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "^2.0.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.3",
+        "bluebird": "^3.5.5",
+        "byte-size": "^5.0.1",
+        "cacache": "^12.0.3",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.3",
+        "ci-info": "^2.0.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.5.1",
+        "cmd-shim": "^3.0.3",
+        "columnify": "~1.5.4",
+        "config-chain": "^1.1.12",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.5.1",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.2.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.3",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.8.5",
+        "iferr": "^1.0.2",
+        "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
+        "inflight": "~1.0.6",
+        "inherits": "^2.0.4",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^3.0.0",
+        "json-parse-better-errors": "^1.0.2",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^4.0.7",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "libnpx": "^10.2.0",
+        "lock-verify": "^2.1.0",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^5.1.1",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "~0.5.1",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^5.0.5",
+        "nopt": "~4.0.1",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.2",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.4",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.6",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.2",
+        "npm-registry-fetch": "^4.0.2",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "^1.5.1",
+        "osenv": "^0.1.5",
+        "pacote": "^9.5.8",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.8.2",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "^1.0.4",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.1.0",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.4.0",
+        "readdir-scoped-modules": "^1.1.0",
+        "request": "^2.88.0",
+        "retry": "^0.12.0",
+        "rimraf": "^2.6.3",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.7.1",
+        "sha": "^3.0.0",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.1",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.13",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.1",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.5.0",
-        "uuid": "3.3.3",
-        "validate-npm-package-license": "3.0.4",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.3.1",
-        "worker-farm": "1.7.0",
-        "write-file-atomic": "2.4.3"
+        "umask": "~1.1.0",
+        "unique-filename": "^1.1.1",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.3.3",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^1.3.1",
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
       },
       "dependencies": {
         "JSONStream": {
@@ -7993,8 +8012,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "abbrev": {
@@ -8007,7 +8026,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "es6-promisify": "5.0.0"
+            "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
@@ -8015,7 +8034,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "humanize-ms": "1.2.1"
+            "humanize-ms": "^1.2.1"
           }
         },
         "ajv": {
@@ -8023,10 +8042,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "ansi-align": {
@@ -8034,7 +8053,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1"
+            "string-width": "^2.0.0"
           }
         },
         "ansi-regex": {
@@ -8047,7 +8066,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "ansicolors": {
@@ -8075,8 +8094,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           },
           "dependencies": {
             "readable-stream": {
@@ -8084,13 +8103,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -8098,7 +8117,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -8113,7 +8132,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
@@ -8147,7 +8166,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "bin-links": {
@@ -8155,11 +8174,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "3.5.5",
-            "cmd-shim": "3.0.3",
-            "gentle-fs": "2.2.1",
-            "graceful-fs": "4.2.3",
-            "write-file-atomic": "2.4.3"
+            "bluebird": "^3.5.3",
+            "cmd-shim": "^3.0.0",
+            "gentle-fs": "^2.0.1",
+            "graceful-fs": "^4.1.15",
+            "write-file-atomic": "^2.3.0"
           }
         },
         "bluebird": {
@@ -8172,13 +8191,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-align": "2.0.0",
-            "camelcase": "4.1.0",
-            "chalk": "2.4.1",
-            "cli-boxes": "1.0.0",
-            "string-width": "2.1.1",
-            "term-size": "1.2.0",
-            "widest-line": "2.0.0"
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
           }
         },
         "brace-expansion": {
@@ -8186,7 +8205,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -8215,21 +8234,21 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "3.5.5",
-            "chownr": "1.1.3",
-            "figgy-pudding": "3.5.1",
-            "glob": "7.1.4",
-            "graceful-fs": "4.2.3",
-            "infer-owner": "1.0.4",
-            "lru-cache": "5.1.1",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.3",
-            "ssri": "6.0.1",
-            "unique-filename": "1.1.1",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
           }
         },
         "call-limit": {
@@ -8257,9 +8276,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "chownr": {
@@ -8277,7 +8296,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip-regex": "2.1.0"
+            "ip-regex": "^2.1.0"
           }
         },
         "cli-boxes": {
@@ -8290,8 +8309,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "3.0.1"
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.1"
           }
         },
         "cli-table3": {
@@ -8299,9 +8318,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "colors": "1.3.3",
-            "object-assign": "4.1.1",
-            "string-width": "2.1.1"
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
           }
         },
         "cliui": {
@@ -8309,9 +8328,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -8324,7 +8343,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -8339,8 +8358,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.3",
-            "mkdirp": "0.5.1"
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
           }
         },
         "co": {
@@ -8358,7 +8377,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "^1.1.1"
           }
         },
         "color-name": {
@@ -8377,8 +8396,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
           }
         },
         "combined-stream": {
@@ -8386,7 +8405,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -8399,10 +8418,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-from": "1.0.0",
-            "inherits": "2.0.4",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           },
           "dependencies": {
             "readable-stream": {
@@ -8410,13 +8429,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -8424,7 +8443,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -8434,8 +8453,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ini": "1.3.5",
-            "proto-list": "1.2.4"
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
           }
         },
         "configstore": {
@@ -8443,12 +8462,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "graceful-fs": "4.2.3",
-            "make-dir": "1.3.0",
-            "unique-string": "1.0.0",
-            "write-file-atomic": "2.4.3",
-            "xdg-basedir": "3.0.0"
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           }
         },
         "console-control-strings": {
@@ -8461,12 +8480,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-write-stream-atomic": "1.0.10",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.3",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
           },
           "dependencies": {
             "aproba": {
@@ -8491,7 +8510,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "capture-stack-trace": "1.0.0"
+            "capture-stack-trace": "^1.0.0"
           }
         },
         "cross-spawn": {
@@ -8499,9 +8518,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.5",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           },
           "dependencies": {
             "lru-cache": {
@@ -8509,8 +8528,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
               }
             },
             "yallist": {
@@ -8535,7 +8554,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "debug": {
@@ -8578,7 +8597,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "clone": "1.0.4"
+            "clone": "^1.0.2"
           }
         },
         "define-properties": {
@@ -8586,7 +8605,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object-keys": "1.0.12"
+            "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
@@ -8614,8 +8633,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asap": "2.0.6",
-            "wrappy": "1.0.2"
+            "asap": "^2.0.0",
+            "wrappy": "1"
           }
         },
         "dot-prop": {
@@ -8623,7 +8642,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-obj": "1.0.1"
+            "is-obj": "^1.0.0"
           }
         },
         "dotenv": {
@@ -8641,10 +8660,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "inherits": "2.0.4",
-            "readable-stream": "2.3.6",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
           },
           "dependencies": {
             "readable-stream": {
@@ -8652,13 +8671,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -8666,7 +8685,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -8677,8 +8696,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2"
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
           }
         },
         "editor": {
@@ -8691,7 +8710,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "iconv-lite": "0.4.23"
+            "iconv-lite": "~0.4.13"
           }
         },
         "end-of-stream": {
@@ -8699,7 +8718,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "env-paths": {
@@ -8717,7 +8736,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "prr": "1.0.1"
+            "prr": "~1.0.1"
           }
         },
         "es-abstract": {
@@ -8725,11 +8744,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "es-to-primitive": "1.2.0",
-            "function-bind": "1.1.1",
-            "has": "1.0.3",
-            "is-callable": "1.1.4",
-            "is-regex": "1.0.4"
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
           }
         },
         "es-to-primitive": {
@@ -8737,9 +8756,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-callable": "1.1.4",
-            "is-date-object": "1.0.1",
-            "is-symbol": "1.0.2"
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
           }
         },
         "es6-promise": {
@@ -8752,7 +8771,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "es6-promise": "4.2.8"
+            "es6-promise": "^4.0.3"
           }
         },
         "escape-string-regexp": {
@@ -8765,13 +8784,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           },
           "dependencies": {
             "get-stream": {
@@ -8816,7 +8835,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "flush-write-stream": {
@@ -8824,8 +8843,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
           },
           "dependencies": {
             "readable-stream": {
@@ -8833,13 +8852,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -8847,7 +8866,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -8862,9 +8881,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
+            "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "2.1.19"
+            "mime-types": "^2.1.12"
           }
         },
         "from2": {
@@ -8872,8 +8891,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
           },
           "dependencies": {
             "readable-stream": {
@@ -8881,13 +8900,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -8895,7 +8914,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -8905,7 +8924,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "2.9.0"
+            "minipass": "^2.6.0"
           },
           "dependencies": {
             "minipass": {
@@ -8913,8 +8932,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             }
           }
@@ -8924,9 +8943,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.3",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.3"
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
           }
         },
         "fs-write-stream-atomic": {
@@ -8934,10 +8953,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.3",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           },
           "dependencies": {
             "iferr": {
@@ -8950,13 +8969,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -8964,7 +8983,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -8984,14 +9003,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           },
           "dependencies": {
             "aproba": {
@@ -9004,9 +9023,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -9021,16 +9040,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "chownr": "1.1.3",
-            "fs-vacuum": "1.2.10",
-            "graceful-fs": "4.2.3",
-            "iferr": "0.1.5",
-            "infer-owner": "1.0.4",
-            "mkdirp": "0.5.1",
-            "path-is-inside": "1.0.2",
-            "read-cmd-shim": "1.0.4",
-            "slide": "1.1.6"
+            "aproba": "^1.1.2",
+            "chownr": "^1.1.2",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "infer-owner": "^1.0.4",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
           },
           "dependencies": {
             "aproba": {
@@ -9055,7 +9074,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "getpass": {
@@ -9063,7 +9082,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "glob": {
@@ -9071,12 +9090,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.4",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "global-dirs": {
@@ -9084,7 +9103,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ini": "1.3.5"
+            "ini": "^1.3.4"
           }
         },
         "got": {
@@ -9092,17 +9111,17 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.1",
-            "safe-buffer": "5.1.2",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
           },
           "dependencies": {
             "get-stream": {
@@ -9127,8 +9146,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
           }
         },
         "has": {
@@ -9136,7 +9155,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "function-bind": "1.1.1"
+            "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
@@ -9169,7 +9188,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "4.3.0",
+            "agent-base": "4",
             "debug": "3.1.0"
           }
         },
@@ -9178,9 +9197,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "https-proxy-agent": {
@@ -9188,8 +9207,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "4.3.0",
-            "debug": "3.1.0"
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
           }
         },
         "humanize-ms": {
@@ -9197,7 +9216,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.0.0"
           }
         },
         "iconv-lite": {
@@ -9205,7 +9224,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "iferr": {
@@ -9218,7 +9237,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "import-lazy": {
@@ -9241,8 +9260,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -9260,14 +9279,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.4",
-            "npm-package-arg": "6.1.1",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.1.0",
-            "semver": "5.7.1",
-            "validate-npm-package-license": "3.0.4",
-            "validate-npm-package-name": "3.0.0"
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "invert-kv": {
@@ -9295,7 +9314,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ci-info": "1.6.0"
+            "ci-info": "^1.0.0"
           },
           "dependencies": {
             "ci-info": {
@@ -9310,7 +9329,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "2.0.10"
+            "cidr-regex": "^2.0.10"
           }
         },
         "is-date-object": {
@@ -9323,7 +9342,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-installed-globally": {
@@ -9331,8 +9350,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "global-dirs": "0.1.1",
-            "is-path-inside": "1.0.1"
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
           }
         },
         "is-npm": {
@@ -9350,7 +9369,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-is-inside": "1.0.2"
+            "path-is-inside": "^1.0.1"
           }
         },
         "is-redirect": {
@@ -9363,7 +9382,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has": "1.0.3"
+            "has": "^1.0.1"
           }
         },
         "is-retry-allowed": {
@@ -9381,7 +9400,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-symbols": "1.0.0"
+            "has-symbols": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -9451,7 +9470,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "package-json": "4.0.1"
+            "package-json": "^4.0.0"
           }
         },
         "lazy-property": {
@@ -9464,7 +9483,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "libcipm": {
@@ -9472,21 +9491,21 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bin-links": "1.1.3",
-            "bluebird": "3.5.5",
-            "figgy-pudding": "3.5.1",
-            "find-npm-prefix": "1.0.2",
-            "graceful-fs": "4.2.3",
-            "ini": "1.3.5",
-            "lock-verify": "2.1.0",
-            "mkdirp": "0.5.1",
-            "npm-lifecycle": "3.1.4",
-            "npm-logical-tree": "1.2.1",
-            "npm-package-arg": "6.1.1",
-            "pacote": "9.5.8",
-            "read-package-json": "2.1.0",
-            "rimraf": "2.6.3",
-            "worker-farm": "1.7.0"
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "ini": "^1.3.5",
+            "lock-verify": "^2.0.2",
+            "mkdirp": "^0.5.1",
+            "npm-lifecycle": "^3.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "pacote": "^9.1.0",
+            "read-package-json": "^2.0.13",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.6.0"
           }
         },
         "libnpm": {
@@ -9494,26 +9513,26 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bin-links": "1.1.3",
-            "bluebird": "3.5.5",
-            "find-npm-prefix": "1.0.2",
-            "libnpmaccess": "3.0.2",
-            "libnpmconfig": "1.2.1",
-            "libnpmhook": "5.0.3",
-            "libnpmorg": "1.0.1",
-            "libnpmpublish": "1.1.2",
-            "libnpmsearch": "2.0.2",
-            "libnpmteam": "1.0.2",
-            "lock-verify": "2.1.0",
-            "npm-lifecycle": "3.1.4",
-            "npm-logical-tree": "1.2.1",
-            "npm-package-arg": "6.1.1",
-            "npm-profile": "4.0.2",
-            "npm-registry-fetch": "4.0.2",
-            "npmlog": "4.1.2",
-            "pacote": "9.5.8",
-            "read-package-json": "2.1.0",
-            "stringify-package": "1.0.1"
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.3",
+            "find-npm-prefix": "^1.0.2",
+            "libnpmaccess": "^3.0.2",
+            "libnpmconfig": "^1.2.1",
+            "libnpmhook": "^5.0.3",
+            "libnpmorg": "^1.0.1",
+            "libnpmpublish": "^1.1.2",
+            "libnpmsearch": "^2.0.2",
+            "libnpmteam": "^1.0.2",
+            "lock-verify": "^2.0.2",
+            "npm-lifecycle": "^3.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "npm-profile": "^4.0.2",
+            "npm-registry-fetch": "^4.0.0",
+            "npmlog": "^4.1.2",
+            "pacote": "^9.5.3",
+            "read-package-json": "^2.0.13",
+            "stringify-package": "^1.0.0"
           }
         },
         "libnpmaccess": {
@@ -9521,10 +9540,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "2.0.0",
-            "get-stream": "4.1.0",
-            "npm-package-arg": "6.1.1",
-            "npm-registry-fetch": "4.0.2"
+            "aproba": "^2.0.0",
+            "get-stream": "^4.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmconfig": {
@@ -9532,9 +9551,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.1",
-            "find-up": "3.0.0",
-            "ini": "1.3.5"
+            "figgy-pudding": "^3.5.1",
+            "find-up": "^3.0.0",
+            "ini": "^1.3.5"
           },
           "dependencies": {
             "find-up": {
@@ -9542,7 +9561,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "locate-path": "3.0.0"
+                "locate-path": "^3.0.0"
               }
             },
             "locate-path": {
@@ -9550,8 +9569,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "p-locate": "3.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
               }
             },
             "p-limit": {
@@ -9559,7 +9578,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "p-try": "2.2.0"
+                "p-try": "^2.0.0"
               }
             },
             "p-locate": {
@@ -9567,7 +9586,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "p-limit": "2.2.0"
+                "p-limit": "^2.0.0"
               }
             },
             "p-try": {
@@ -9582,10 +9601,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "2.0.0",
-            "figgy-pudding": "3.5.1",
-            "get-stream": "4.1.0",
-            "npm-registry-fetch": "4.0.2"
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmorg": {
@@ -9593,10 +9612,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "2.0.0",
-            "figgy-pudding": "3.5.1",
-            "get-stream": "4.1.0",
-            "npm-registry-fetch": "4.0.2"
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmpublish": {
@@ -9604,15 +9623,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "2.0.0",
-            "figgy-pudding": "3.5.1",
-            "get-stream": "4.1.0",
-            "lodash.clonedeep": "4.5.0",
-            "normalize-package-data": "2.5.0",
-            "npm-package-arg": "6.1.1",
-            "npm-registry-fetch": "4.0.2",
-            "semver": "5.7.1",
-            "ssri": "6.0.1"
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "lodash.clonedeep": "^4.5.0",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0",
+            "semver": "^5.5.1",
+            "ssri": "^6.0.1"
           }
         },
         "libnpmsearch": {
@@ -9620,9 +9639,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.1",
-            "get-stream": "4.1.0",
-            "npm-registry-fetch": "4.0.2"
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmteam": {
@@ -9630,10 +9649,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "2.0.0",
-            "figgy-pudding": "3.5.1",
-            "get-stream": "4.1.0",
-            "npm-registry-fetch": "4.0.2"
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpx": {
@@ -9641,14 +9660,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dotenv": "5.0.1",
-            "npm-package-arg": "6.1.1",
-            "rimraf": "2.6.3",
-            "safe-buffer": "5.1.2",
-            "update-notifier": "2.5.0",
-            "which": "1.3.1",
-            "y18n": "4.0.0",
-            "yargs": "11.0.0"
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
           }
         },
         "locate-path": {
@@ -9656,8 +9675,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "lock-verify": {
@@ -9665,8 +9684,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "6.1.1",
-            "semver": "5.7.1"
+            "npm-package-arg": "^6.1.0",
+            "semver": "^5.4.1"
           }
         },
         "lockfile": {
@@ -9674,7 +9693,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "signal-exit": "3.0.2"
+            "signal-exit": "^3.0.2"
           }
         },
         "lodash._baseindexof": {
@@ -9687,8 +9706,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
           }
         },
         "lodash._bindcallback": {
@@ -9706,7 +9725,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._getnative": "3.9.1"
+            "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._createset": {
@@ -9759,7 +9778,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "yallist": "3.0.3"
+            "yallist": "^3.0.2"
           }
         },
         "make-dir": {
@@ -9767,7 +9786,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "make-fetch-happen": {
@@ -9775,17 +9794,17 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "agentkeepalive": "3.5.2",
-            "cacache": "12.0.3",
-            "http-cache-semantics": "3.8.1",
-            "http-proxy-agent": "2.1.0",
-            "https-proxy-agent": "2.2.2",
-            "lru-cache": "5.1.1",
-            "mississippi": "3.0.0",
-            "node-fetch-npm": "2.0.2",
-            "promise-retry": "1.1.1",
-            "socks-proxy-agent": "4.0.2",
-            "ssri": "6.0.1"
+            "agentkeepalive": "^3.4.1",
+            "cacache": "^12.0.0",
+            "http-cache-semantics": "^3.8.1",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.1",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "node-fetch-npm": "^2.0.2",
+            "promise-retry": "^1.1.1",
+            "socks-proxy-agent": "^4.0.0",
+            "ssri": "^6.0.0"
           }
         },
         "meant": {
@@ -9798,7 +9817,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "mime-db": {
@@ -9811,7 +9830,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.35.0"
+            "mime-db": "~1.35.0"
           }
         },
         "mimic-fn": {
@@ -9824,7 +9843,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -9837,7 +9856,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "2.9.0"
+            "minipass": "^2.9.0"
           },
           "dependencies": {
             "minipass": {
@@ -9845,8 +9864,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             }
           }
@@ -9856,16 +9875,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "duplexify": "3.6.0",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.3",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.5.1",
-            "stream-each": "1.2.2",
-            "through2": "2.0.3"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           }
         },
         "mkdirp": {
@@ -9881,12 +9900,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.3",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
           },
           "dependencies": {
             "aproba": {
@@ -9911,9 +9930,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "encoding": "0.1.12",
-            "json-parse-better-errors": "1.0.2",
-            "safe-buffer": "5.1.2"
+            "encoding": "^0.1.11",
+            "json-parse-better-errors": "^1.0.0",
+            "safe-buffer": "^5.1.1"
           }
         },
         "node-gyp": {
@@ -9921,17 +9940,17 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "env-paths": "1.0.0",
-            "glob": "7.1.4",
-            "graceful-fs": "4.2.3",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "request": "2.88.0",
-            "rimraf": "2.6.3",
-            "semver": "5.3.0",
-            "tar": "4.4.13",
-            "which": "1.3.1"
+            "env-paths": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^4.4.12",
+            "which": "1"
           },
           "dependencies": {
             "nopt": {
@@ -9939,7 +9958,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
               }
             },
             "semver": {
@@ -9954,8 +9973,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "normalize-package-data": {
@@ -9963,10 +9982,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.8.5",
-            "resolve": "1.10.0",
-            "semver": "5.7.1",
-            "validate-npm-package-license": "3.0.4"
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           },
           "dependencies": {
             "resolve": {
@@ -9974,7 +9993,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.6"
               }
             }
           }
@@ -9984,8 +10003,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cli-table3": "0.5.1",
-            "console-control-strings": "1.1.0"
+            "cli-table3": "^0.5.0",
+            "console-control-strings": "^1.1.0"
           }
         },
         "npm-bundled": {
@@ -10003,7 +10022,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "5.7.1"
+            "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
@@ -10011,14 +10030,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "byline": "5.0.0",
-            "graceful-fs": "4.2.3",
-            "node-gyp": "5.0.5",
-            "resolve-from": "4.0.0",
-            "slide": "1.1.6",
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.15",
+            "node-gyp": "^5.0.2",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.1"
+            "umask": "^1.1.0",
+            "which": "^1.3.1"
           }
         },
         "npm-logical-tree": {
@@ -10031,10 +10050,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.8.5",
-            "osenv": "0.1.5",
-            "semver": "5.7.1",
-            "validate-npm-package-name": "3.0.0"
+            "hosted-git-info": "^2.7.1",
+            "osenv": "^0.1.5",
+            "semver": "^5.6.0",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
@@ -10042,8 +10061,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ignore-walk": "3.0.3",
-            "npm-bundled": "1.0.6"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
@@ -10051,9 +10070,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.1",
-            "npm-package-arg": "6.1.1",
-            "semver": "5.7.1"
+            "figgy-pudding": "^3.5.1",
+            "npm-package-arg": "^6.0.0",
+            "semver": "^5.4.1"
           }
         },
         "npm-profile": {
@@ -10061,9 +10080,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "2.0.0",
-            "figgy-pudding": "3.5.1",
-            "npm-registry-fetch": "4.0.2"
+            "aproba": "^1.1.2 || 2",
+            "figgy-pudding": "^3.4.1",
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "npm-registry-fetch": {
@@ -10071,13 +10090,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.5",
-            "bluebird": "3.5.5",
-            "figgy-pudding": "3.5.1",
-            "lru-cache": "5.1.1",
-            "make-fetch-happen": "5.0.0",
-            "npm-package-arg": "6.1.1",
-            "safe-buffer": "5.2.0"
+            "JSONStream": "^1.3.4",
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.4.1",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
+            "npm-package-arg": "^6.1.0",
+            "safe-buffer": "^5.2.0"
           },
           "dependencies": {
             "safe-buffer": {
@@ -10092,7 +10111,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "npm-user-validate": {
@@ -10105,10 +10124,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -10136,8 +10155,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-properties": "1.1.3",
-            "es-abstract": "1.12.0"
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
           }
         },
         "once": {
@@ -10145,7 +10164,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "opener": {
@@ -10163,9 +10182,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "os-tmpdir": {
@@ -10178,8 +10197,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "p-finally": {
@@ -10192,7 +10211,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -10200,7 +10219,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "1.2.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -10213,10 +10232,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "got": "6.7.1",
-            "registry-auth-token": "3.3.2",
-            "registry-url": "3.1.0",
-            "semver": "5.7.1"
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
           }
         },
         "pacote": {
@@ -10224,35 +10243,35 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "3.5.5",
-            "cacache": "12.0.3",
-            "chownr": "1.1.3",
-            "figgy-pudding": "3.5.1",
-            "get-stream": "4.1.0",
-            "glob": "7.1.4",
-            "infer-owner": "1.0.4",
-            "lru-cache": "5.1.1",
-            "make-fetch-happen": "5.0.0",
-            "minimatch": "3.0.4",
-            "minipass": "2.3.5",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.5.0",
-            "npm-package-arg": "6.1.1",
-            "npm-packlist": "1.4.6",
-            "npm-pick-manifest": "3.0.2",
-            "npm-registry-fetch": "4.0.2",
-            "osenv": "0.1.5",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "5.0.1",
-            "rimraf": "2.6.3",
-            "safe-buffer": "5.1.2",
-            "semver": "5.7.1",
-            "ssri": "6.0.1",
-            "tar": "4.4.13",
-            "unique-filename": "1.1.1",
-            "which": "1.3.1"
+            "bluebird": "^3.5.3",
+            "cacache": "^12.0.2",
+            "chownr": "^1.1.2",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.1.0",
+            "glob": "^7.1.3",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
+            "minimatch": "^3.0.4",
+            "minipass": "^2.3.5",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-packlist": "^1.1.12",
+            "npm-pick-manifest": "^3.0.0",
+            "npm-registry-fetch": "^4.0.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.1",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.2",
+            "semver": "^5.6.0",
+            "ssri": "^6.0.1",
+            "tar": "^4.4.10",
+            "unique-filename": "^1.1.1",
+            "which": "^1.3.1"
           },
           "dependencies": {
             "minipass": {
@@ -10260,8 +10279,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             }
           }
@@ -10271,9 +10290,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cyclist": "0.2.2",
-            "inherits": "2.0.4",
-            "readable-stream": "2.3.6"
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
           },
           "dependencies": {
             "readable-stream": {
@@ -10281,13 +10300,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -10295,7 +10314,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -10355,8 +10374,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "err-code": "1.1.2",
-            "retry": "0.10.1"
+            "err-code": "^1.0.0",
+            "retry": "^0.10.0"
           },
           "dependencies": {
             "retry": {
@@ -10371,7 +10390,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "read": "1.0.7"
+            "read": "1"
           }
         },
         "proto-list": {
@@ -10384,7 +10403,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "genfun": "5.0.0"
+            "genfun": "^5.0.0"
           }
         },
         "prr": {
@@ -10407,8 +10426,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "pumpify": {
@@ -10416,9 +10435,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "duplexify": "3.6.0",
-            "inherits": "2.0.4",
-            "pump": "2.0.1"
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
           },
           "dependencies": {
             "pump": {
@@ -10426,8 +10445,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             }
           }
@@ -10452,9 +10471,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "split-on-first": "1.1.0",
-            "strict-uri-encode": "2.0.0"
+            "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
           }
         },
         "qw": {
@@ -10467,10 +10486,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -10485,7 +10504,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mute-stream": "0.0.7"
+            "mute-stream": "~0.0.4"
           }
         },
         "read-cmd-shim": {
@@ -10493,7 +10512,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.3"
+            "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
@@ -10501,13 +10520,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.2.3",
-            "read-package-json": "2.1.0",
-            "readdir-scoped-modules": "1.1.0",
-            "semver": "5.7.1",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           }
         },
         "read-package-json": {
@@ -10515,11 +10534,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.4",
-            "graceful-fs": "4.2.3",
-            "json-parse-better-errors": "1.0.2",
-            "normalize-package-data": "2.5.0",
-            "slash": "1.0.0"
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "slash": "^1.0.0"
           }
         },
         "read-package-tree": {
@@ -10527,9 +10546,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "read-package-json": "2.1.0",
-            "readdir-scoped-modules": "1.1.0",
-            "util-promisify": "2.1.0"
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
           }
         },
         "readable-stream": {
@@ -10537,9 +10556,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "string_decoder": "1.2.0",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "readdir-scoped-modules": {
@@ -10547,10 +10566,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.2.3",
-            "once": "1.4.0"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "registry-auth-token": {
@@ -10558,8 +10577,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "rc": "1.2.7",
-            "safe-buffer": "5.1.2"
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
           }
         },
         "registry-url": {
@@ -10567,7 +10586,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "rc": "1.2.7"
+            "rc": "^1.0.1"
           }
         },
         "request": {
@@ -10575,26 +10594,26 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.1.0",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.19",
-            "oauth-sign": "0.9.0",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "tough-cookie": "2.4.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.3.3"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
           }
         },
         "require-directory": {
@@ -10622,7 +10641,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.4"
+            "glob": "^7.1.3"
           }
         },
         "run-queue": {
@@ -10630,7 +10649,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.2.0"
+            "aproba": "^1.1.1"
           },
           "dependencies": {
             "aproba": {
@@ -10660,7 +10679,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "5.7.1"
+            "semver": "^5.0.3"
           }
         },
         "set-blocking": {
@@ -10673,7 +10692,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.3"
+            "graceful-fs": "^4.1.2"
           }
         },
         "shebang-command": {
@@ -10681,7 +10700,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -10714,7 +10733,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip": "1.1.5",
+            "ip": "^1.1.5",
             "smart-buffer": "4.0.2"
           }
         },
@@ -10723,8 +10742,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "4.2.1",
-            "socks": "2.3.2"
+            "agent-base": "~4.2.1",
+            "socks": "~2.3.2"
           },
           "dependencies": {
             "agent-base": {
@@ -10732,7 +10751,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "es6-promisify": "5.0.0"
+                "es6-promisify": "^5.0.0"
               }
             }
           }
@@ -10747,8 +10766,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
           },
           "dependencies": {
             "from2": {
@@ -10756,8 +10775,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "2.0.4",
-                "readable-stream": "1.1.14"
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
               }
             },
             "isarray": {
@@ -10770,10 +10789,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "string_decoder": {
@@ -10788,8 +10807,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.3"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -10802,8 +10821,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.3"
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -10821,15 +10840,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asn1": "0.2.4",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.2",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.2",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
           }
         },
         "ssri": {
@@ -10837,7 +10856,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.1"
+            "figgy-pudding": "^3.5.1"
           }
         },
         "stream-each": {
@@ -10845,8 +10864,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
           }
         },
         "stream-iterate": {
@@ -10854,8 +10873,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "stream-shift": "1.0.0"
+            "readable-stream": "^2.1.5",
+            "stream-shift": "^1.0.0"
           },
           "dependencies": {
             "readable-stream": {
@@ -10863,13 +10882,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -10877,7 +10896,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -10897,8 +10916,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -10916,7 +10935,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -10926,7 +10945,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "stringify-package": {
@@ -10939,7 +10958,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-eof": {
@@ -10957,7 +10976,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "tar": {
@@ -10965,13 +10984,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chownr": "1.1.3",
-            "fs-minipass": "1.2.7",
-            "minipass": "2.9.0",
-            "minizlib": "1.3.3",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
           },
           "dependencies": {
             "minipass": {
@@ -10979,8 +10998,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             }
           }
@@ -10990,7 +11009,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0"
+            "execa": "^0.7.0"
           }
         },
         "text-table": {
@@ -11008,8 +11027,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -11017,13 +11036,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -11031,7 +11050,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -11051,8 +11070,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -11060,7 +11079,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -11089,7 +11108,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "unique-slug": "2.0.0"
+            "unique-slug": "^2.0.0"
           }
         },
         "unique-slug": {
@@ -11097,7 +11116,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "imurmurhash": "0.1.4"
+            "imurmurhash": "^0.1.4"
           }
         },
         "unique-string": {
@@ -11105,7 +11124,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "crypto-random-string": "1.0.0"
+            "crypto-random-string": "^1.0.0"
           }
         },
         "unpipe": {
@@ -11123,16 +11142,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boxen": "1.3.0",
-            "chalk": "2.4.1",
-            "configstore": "3.1.2",
-            "import-lazy": "2.1.0",
-            "is-ci": "1.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           }
         },
         "url-parse-lax": {
@@ -11140,7 +11159,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "prepend-http": "1.0.4"
+            "prepend-http": "^1.0.1"
           }
         },
         "util-deprecate": {
@@ -11158,7 +11177,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object.getownpropertydescriptors": "2.0.3"
+            "object.getownpropertydescriptors": "^2.0.3"
           }
         },
         "uuid": {
@@ -11171,8 +11190,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "validate-npm-package-name": {
@@ -11180,7 +11199,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "^1.0.3"
           }
         },
         "verror": {
@@ -11188,9 +11207,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "wcwidth": {
@@ -11198,7 +11217,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "defaults": "1.0.3"
+            "defaults": "^1.0.3"
           }
         },
         "which": {
@@ -11206,7 +11225,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -11219,7 +11238,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           },
           "dependencies": {
             "string-width": {
@@ -11227,9 +11246,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -11239,7 +11258,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1"
+            "string-width": "^2.1.1"
           }
         },
         "worker-farm": {
@@ -11247,7 +11266,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "errno": "0.1.7"
+            "errno": "~0.1.7"
           }
         },
         "wrap-ansi": {
@@ -11255,8 +11274,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
@@ -11264,9 +11283,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -11281,9 +11300,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.3",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
           }
         },
         "xdg-basedir": {
@@ -11311,18 +11330,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
             "y18n": {
@@ -11337,7 +11356,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -11348,7 +11367,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -11357,10 +11376,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -11369,7 +11388,7 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -11408,9 +11427,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -11419,7 +11438,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -11428,7 +11447,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -11445,7 +11464,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.getownpropertydescriptors": {
@@ -11454,8 +11473,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.omit": {
@@ -11464,8 +11483,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -11474,7 +11493,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "object.values": {
@@ -11483,10 +11502,10 @@
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "octokit-pagination-methods": {
@@ -11501,7 +11520,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -11510,7 +11529,7 @@
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
-        "mimic-fn": "2.1.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optimist": {
@@ -11519,8 +11538,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -11537,12 +11556,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -11565,8 +11584,8 @@
       "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
       "dev": true,
       "requires": {
-        "macos-release": "2.3.0",
-        "windows-release": "3.2.0"
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
       }
     },
     "p-each-series": {
@@ -11575,7 +11594,7 @@
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "requires": {
-        "p-reduce": "1.0.0"
+        "p-reduce": "^1.0.0"
       }
     },
     "p-filter": {
@@ -11584,7 +11603,7 @@
       "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
       "dev": true,
       "requires": {
-        "p-map": "2.1.0"
+        "p-map": "^2.0.0"
       }
     },
     "p-finally": {
@@ -11605,7 +11624,7 @@
       "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "dev": true,
       "requires": {
-        "p-try": "2.2.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
@@ -11614,7 +11633,7 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "p-limit": "2.2.1"
+        "p-limit": "^2.0.0"
       }
     },
     "p-map": {
@@ -11641,8 +11660,8 @@
       "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
       "dev": true,
       "requires": {
-        "@types/retry": "0.12.0",
-        "retry": "0.12.0"
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
       }
     },
     "p-try": {
@@ -11657,7 +11676,7 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
-        "callsites": "3.1.0"
+        "callsites": "^3.0.0"
       }
     },
     "parse-glob": {
@@ -11666,10 +11685,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -11678,8 +11697,8 @@
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2",
-        "json-parse-better-errors": "1.0.2"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse5": {
@@ -11724,7 +11743,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "performance-now": {
@@ -11751,7 +11770,7 @@
       "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
       "dev": true,
       "requires": {
-        "node-modules-regexp": "1.0.0"
+        "node-modules-regexp": "^1.0.0"
       }
     },
     "pkg-conf": {
@@ -11760,8 +11779,8 @@
       "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "load-json-file": "4.0.0"
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -11770,7 +11789,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "locate-path": {
@@ -11779,8 +11798,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -11789,7 +11808,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -11798,7 +11817,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -11815,7 +11834,7 @@
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
       "requires": {
-        "find-up": "3.0.0"
+        "find-up": "^3.0.0"
       }
     },
     "pn": {
@@ -11836,9 +11855,9 @@
       "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "source-map": "0.6.1",
-        "supports-color": "6.1.0"
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "supports-color": {
@@ -11847,7 +11866,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -11858,10 +11877,10 @@
       "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
       "dev": true,
       "requires": {
-        "css-unit-converter": "1.1.1",
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "5.0.0",
-        "postcss-value-parser": "3.3.1"
+        "css-unit-converter": "^1.1.1",
+        "postcss": "^7.0.5",
+        "postcss-selector-parser": "^5.0.0-rc.4",
+        "postcss-value-parser": "^3.3.1"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11878,11 +11897,11 @@
       "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.6.6",
-        "color": "3.1.2",
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.0.0",
+        "color": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11899,8 +11918,8 @@
       "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11917,7 +11936,7 @@
       "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-duplicates": {
@@ -11926,7 +11945,7 @@
       "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-empty": {
@@ -11935,7 +11954,7 @@
       "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-overridden": {
@@ -11944,7 +11963,7 @@
       "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-unused": {
@@ -11953,8 +11972,8 @@
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "postcss": "^5.0.14",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11975,11 +11994,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12002,10 +12021,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.5.1",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -12020,7 +12039,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -12029,7 +12048,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12040,7 +12059,7 @@
       "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12061,11 +12080,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12088,10 +12107,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.5.1",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -12106,7 +12125,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -12115,7 +12134,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12126,10 +12145,10 @@
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1",
-        "postcss-load-options": "1.2.0",
-        "postcss-load-plugins": "2.3.0"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0",
+        "postcss-load-options": "^1.2.0",
+        "postcss-load-plugins": "^2.3.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -12138,13 +12157,13 @@
           "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.13.1",
-            "minimist": "1.2.0",
-            "object-assign": "4.1.1",
-            "os-homedir": "1.0.2",
-            "parse-json": "2.2.0",
-            "require-from-string": "1.2.1"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
           }
         },
         "parse-json": {
@@ -12153,7 +12172,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2"
+            "error-ex": "^1.2.0"
           }
         }
       }
@@ -12164,8 +12183,8 @@
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -12174,13 +12193,13 @@
           "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.13.1",
-            "minimist": "1.2.0",
-            "object-assign": "4.1.1",
-            "os-homedir": "1.0.2",
-            "parse-json": "2.2.0",
-            "require-from-string": "1.2.1"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
           }
         },
         "parse-json": {
@@ -12189,7 +12208,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2"
+            "error-ex": "^1.2.0"
           }
         }
       }
@@ -12200,8 +12219,8 @@
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.1",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -12210,13 +12229,13 @@
           "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.13.1",
-            "minimist": "1.2.0",
-            "object-assign": "4.1.1",
-            "os-homedir": "1.0.2",
-            "parse-json": "2.2.0",
-            "require-from-string": "1.2.1"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
           }
         },
         "parse-json": {
@@ -12225,7 +12244,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2"
+            "error-ex": "^1.2.0"
           }
         }
       }
@@ -12236,9 +12255,9 @@
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
-        "has": "1.0.3",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.1"
+        "has": "^1.0.1",
+        "postcss": "^5.0.10",
+        "postcss-value-parser": "^3.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12259,11 +12278,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12286,10 +12305,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.5.1",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "postcss-value-parser": {
@@ -12310,7 +12329,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -12319,7 +12338,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12331,9 +12350,9 @@
       "dev": true,
       "requires": {
         "css-color-names": "0.0.4",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1",
-        "stylehacks": "4.0.3"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "stylehacks": "^4.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12350,12 +12369,12 @@
       "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
       "dev": true,
       "requires": {
-        "browserslist": "4.6.6",
-        "caniuse-api": "3.0.0",
-        "cssnano-util-same-parent": "4.0.1",
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "3.1.1",
-        "vendors": "1.0.3"
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-util-same-parent": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "vendors": "^1.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -12364,9 +12383,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -12383,8 +12402,8 @@
       "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12401,10 +12420,10 @@
       "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "is-color-stop": "1.1.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "is-color-stop": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12421,12 +12440,12 @@
       "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "browserslist": "4.6.6",
-        "cssnano-util-get-arguments": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.0",
+        "browserslist": "^4.0.0",
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12443,10 +12462,10 @@
       "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "3.1.1"
+        "alphanum-sort": "^1.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -12455,9 +12474,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -12468,11 +12487,11 @@
       "integrity": "sha512-btTrbK+Xc3NBuYF8TPBjCMRSp5h6NoQ1iVZ6WiDQENIze6KIYCSf0+UFQuV3yJ7gRHA+4AAtF8i2jRvUpbBMMg==",
       "dev": true,
       "requires": {
-        "css-modules-loader-core": "1.1.0",
-        "generic-names": "1.0.3",
-        "lodash.camelcase": "4.3.0",
-        "postcss": "7.0.17",
-        "string-hash": "1.1.3"
+        "css-modules-loader-core": "^1.1.0",
+        "generic-names": "^1.0.3",
+        "lodash.camelcase": "^4.3.0",
+        "postcss": "^7.0.1",
+        "string-hash": "^1.1.1"
       }
     },
     "postcss-modules-extract-imports": {
@@ -12481,7 +12500,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.23"
+        "postcss": "^6.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -12490,9 +12509,9 @@
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.2",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         }
       }
@@ -12503,8 +12522,8 @@
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "0.7.1",
-        "postcss": "6.0.23"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -12513,9 +12532,9 @@
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.2",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         }
       }
@@ -12526,8 +12545,8 @@
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "0.7.1",
-        "postcss": "6.0.23"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -12536,9 +12555,9 @@
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.2",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         }
       }
@@ -12549,8 +12568,8 @@
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
       "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.23"
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -12559,9 +12578,9 @@
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.2",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           }
         }
       }
@@ -12572,7 +12591,7 @@
       "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-normalize-display-values": {
@@ -12581,9 +12600,9 @@
       "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12600,10 +12619,10 @@
       "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12620,10 +12639,10 @@
       "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12640,9 +12659,9 @@
       "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
       "dev": true,
       "requires": {
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12659,9 +12678,9 @@
       "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12678,9 +12697,9 @@
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "dev": true,
       "requires": {
-        "browserslist": "4.6.6",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12697,10 +12716,10 @@
       "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
       "dev": true,
       "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "3.3.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12717,8 +12736,8 @@
       "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12735,9 +12754,9 @@
       "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12754,8 +12773,8 @@
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12776,11 +12795,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12803,10 +12822,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.5.1",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "postcss-value-parser": {
@@ -12827,7 +12846,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -12836,7 +12855,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12847,10 +12866,10 @@
       "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
       "dev": true,
       "requires": {
-        "browserslist": "4.6.6",
-        "caniuse-api": "3.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.17"
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0"
       }
     },
     "postcss-reduce-transforms": {
@@ -12859,10 +12878,10 @@
       "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12879,9 +12898,9 @@
       "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
       "dev": true,
       "requires": {
-        "cssesc": "2.0.0",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "cssesc": "^2.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "postcss-svgo": {
@@ -12890,10 +12909,10 @@
       "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
       "dev": true,
       "requires": {
-        "is-svg": "3.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1",
-        "svgo": "1.3.0"
+        "is-svg": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "svgo": "^1.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12910,9 +12929,9 @@
       "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "7.0.17",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
       }
     },
     "postcss-value-parser": {
@@ -12927,9 +12946,9 @@
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
-        "has": "1.0.3",
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12950,11 +12969,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12977,10 +12996,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.5.1",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -12995,7 +13014,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -13004,7 +13023,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13015,22 +13034,22 @@
       "integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
       "dev": true,
       "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "2.0.3",
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "napi-build-utils": "1.0.1",
-        "node-abi": "2.10.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.8",
-        "simple-get": "2.8.1",
-        "tar-fs": "1.16.3",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.2.7",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
       },
       "dependencies": {
         "pump": {
@@ -13039,8 +13058,8 @@
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -13081,10 +13100,10 @@
       "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
       "dev": true,
       "requires": {
-        "@jest/types": "24.9.0",
-        "ansi-regex": "4.1.0",
-        "ansi-styles": "3.2.1",
-        "react-is": "16.9.0"
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
       }
     },
     "process-nextick-args": {
@@ -13105,8 +13124,8 @@
       "integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
       "dev": true,
       "requires": {
-        "kleur": "3.0.3",
-        "sisteransi": "1.0.3"
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.3"
       }
     },
     "psl": {
@@ -13121,8 +13140,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -13149,8 +13168,8 @@
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "quick-lru": {
@@ -13165,9 +13184,9 @@
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.4"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -13184,10 +13203,10 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "react-is": {
@@ -13202,9 +13221,9 @@
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
-        "load-json-file": "4.0.0",
-        "normalize-package-data": "2.5.0",
-        "path-type": "3.0.0"
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
       }
     },
     "read-pkg-up": {
@@ -13213,8 +13232,8 @@
       "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
       "dev": true,
       "requires": {
-        "find-up": "3.0.0",
-        "read-pkg": "3.0.0"
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -13223,13 +13242,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.4",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.1",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "realpath-native": {
@@ -13238,7 +13257,7 @@
       "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
       "dev": true,
       "requires": {
-        "util.promisify": "1.0.0"
+        "util.promisify": "^1.0.0"
       }
     },
     "redent": {
@@ -13247,8 +13266,8 @@
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
-        "indent-string": "3.2.0",
-        "strip-indent": "2.0.0"
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "redeyed": {
@@ -13257,7 +13276,7 @@
       "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
       "dev": true,
       "requires": {
-        "esprima": "4.0.1"
+        "esprima": "~4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -13274,9 +13293,9 @@
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
-        "balanced-match": "0.4.2",
-        "math-expression-evaluator": "1.2.17",
-        "reduce-function-call": "1.0.2"
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
       },
       "dependencies": {
         "balanced-match": {
@@ -13293,7 +13312,7 @@
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
-        "balanced-match": "0.4.2"
+        "balanced-match": "^0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -13316,7 +13335,7 @@
       "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0"
+        "regenerate": "^1.4.0"
       }
     },
     "regenerator-runtime": {
@@ -13331,7 +13350,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -13340,8 +13359,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpu-core": {
@@ -13350,12 +13369,12 @@
       "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0",
-        "regenerate-unicode-properties": "8.1.0",
-        "regjsgen": "0.5.0",
-        "regjsparser": "0.6.0",
-        "unicode-match-property-ecmascript": "1.0.4",
-        "unicode-match-property-value-ecmascript": "1.1.0"
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.0.2",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
       }
     },
     "registry-auth-token": {
@@ -13364,8 +13383,8 @@
       "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
       "dev": true,
       "requires": {
-        "rc": "1.2.8",
-        "safe-buffer": "5.1.2"
+        "rc": "^1.2.8",
+        "safe-buffer": "^5.0.1"
       }
     },
     "regjsgen": {
@@ -13380,7 +13399,7 @@
       "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -13415,26 +13434,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.8",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.24",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.3"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "punycode": {
@@ -13449,8 +13468,8 @@
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
-            "psl": "1.3.0",
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
         }
       }
@@ -13461,7 +13480,7 @@
       "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.11"
       }
     },
     "request-promise-native": {
@@ -13471,8 +13490,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.2",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.5.0"
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "require-directory": {
@@ -13505,7 +13524,7 @@
       "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
@@ -13514,7 +13533,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-from": {
@@ -13529,7 +13548,7 @@
       "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.1"
+        "global-dirs": "^0.1.1"
       }
     },
     "resolve-url": {
@@ -13574,7 +13593,7 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.4"
+        "glob": "^7.1.3"
       }
     },
     "rollup": {
@@ -13584,7 +13603,7 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "12.7.1"
+        "@types/node": "*"
       }
     },
     "rollup-plugin-alias": {
@@ -13593,7 +13612,7 @@
       "integrity": "sha512-ODeZXhTxpD48sfcYLAFc1BGrsXKDj7o1CSNH3uYbdK3o0NxyMmaQPTNgW+ko+am92DLC8QSTe4kyxTuEkI5S5w==",
       "dev": true,
       "requires": {
-        "slash": "3.0.0"
+        "slash": "^3.0.0"
       },
       "dependencies": {
         "slash": {
@@ -13610,8 +13629,8 @@
       "integrity": "sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "rollup-pluginutils": "2.8.1"
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.8.1"
       }
     },
     "rollup-plugin-buble": {
@@ -13620,8 +13639,8 @@
       "integrity": "sha512-8J4zPk2DQdk3rxeZvxgzhHh/rm5nJkjwgcsUYisCQg1QbT5yagW+hehYEW7ZNns/NVbDCTv4JQ7h4fC8qKGOKw==",
       "dev": true,
       "requires": {
-        "buble": "0.19.8",
-        "rollup-pluginutils": "2.8.1"
+        "buble": "^0.19.8",
+        "rollup-pluginutils": "^2.3.3"
       }
     },
     "rollup-plugin-bundle-size": {
@@ -13630,8 +13649,8 @@
       "integrity": "sha512-aWj0Pvzq90fqbI5vN1IvUrlf4utOqy+AERYxwWjegH1G8PzheMnrRIgQ5tkwKVtQMDP0bHZEACW/zLDF+XgfXQ==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "maxmin": "2.1.0"
+        "chalk": "^1.1.3",
+        "maxmin": "^2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13652,11 +13671,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -13665,7 +13684,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -13682,10 +13701,10 @@
       "integrity": "sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==",
       "dev": true,
       "requires": {
-        "estree-walker": "0.6.1",
-        "magic-string": "0.25.3",
-        "resolve": "1.12.0",
-        "rollup-pluginutils": "2.8.1"
+        "estree-walker": "^0.6.0",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.10.0",
+        "rollup-pluginutils": "^2.6.0"
       }
     },
     "rollup-plugin-es3": {
@@ -13694,7 +13713,7 @@
       "integrity": "sha512-jTMqQgMZ/tkjRW4scf4ln5c0OiTSi+Lx/IEyFd41ldgGoLvvg9AQxmVOl93+KaoyB7XRYToYjiHDvO40NPF/fA==",
       "dev": true,
       "requires": {
-        "magic-string": "0.22.5"
+        "magic-string": "^0.22.4"
       },
       "dependencies": {
         "magic-string": {
@@ -13703,7 +13722,7 @@
           "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
           "dev": true,
           "requires": {
-            "vlq": "0.2.3"
+            "vlq": "^0.2.2"
           }
         }
       }
@@ -13714,8 +13733,8 @@
       "integrity": "sha1-bOVo8d1Vlma3erdrS64lFAdSjbY=",
       "dev": true,
       "requires": {
-        "flow-remove-types": "1.2.3",
-        "rollup-pluginutils": "1.5.2"
+        "flow-remove-types": "^1.1.0",
+        "rollup-pluginutils": "^1.5.1"
       },
       "dependencies": {
         "estree-walker": {
@@ -13730,8 +13749,8 @@
           "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
           "dev": true,
           "requires": {
-            "estree-walker": "0.2.1",
-            "minimatch": "3.0.4"
+            "estree-walker": "^0.2.1",
+            "minimatch": "^3.0.2"
           }
         }
       }
@@ -13742,7 +13761,7 @@
       "integrity": "sha512-BlYk5VspvGpjz7lAwArVzBXR60JK+4EKtPkCHouAWg39obk9S61hZYJDBfMK+oitPdoe11i69TlxKlMQNFC/Uw==",
       "dev": true,
       "requires": {
-        "rollup-pluginutils": "2.8.1"
+        "rollup-pluginutils": "^2.3.1"
       }
     },
     "rollup-plugin-node-resolve": {
@@ -13752,9 +13771,9 @@
       "dev": true,
       "requires": {
         "@types/resolve": "0.0.8",
-        "builtin-modules": "3.1.0",
-        "is-module": "1.0.0",
-        "resolve": "1.12.0"
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.10.0"
       }
     },
     "rollup-plugin-postcss": {
@@ -13763,21 +13782,21 @@
       "integrity": "sha512-se1qftVETua9ZGViud4A4gbgEQenjYnLPvjh3kTqbBZU+f0mQ9YvJptIuzPhEk5kZAHZhkwIkk2jk+byrn1XPA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "concat-with-sourcemaps": "1.1.0",
-        "cssnano": "3.10.0",
-        "fs-extra": "5.0.0",
-        "import-cwd": "2.1.0",
-        "p-queue": "2.4.2",
-        "pify": "3.0.0",
-        "postcss": "6.0.23",
-        "postcss-load-config": "1.2.0",
-        "postcss-modules": "1.4.1",
-        "promise.series": "0.2.0",
-        "reserved-words": "0.1.2",
-        "resolve": "1.12.0",
-        "rollup-pluginutils": "2.8.1",
-        "style-inject": "0.3.0"
+        "chalk": "^2.0.0",
+        "concat-with-sourcemaps": "^1.0.5",
+        "cssnano": "^3.10.0",
+        "fs-extra": "^5.0.0",
+        "import-cwd": "^2.1.0",
+        "p-queue": "^2.4.2",
+        "pify": "^3.0.0",
+        "postcss": "^6.0.21",
+        "postcss-load-config": "^1.2.0",
+        "postcss-modules": "^1.1.0",
+        "promise.series": "^0.2.0",
+        "reserved-words": "^0.1.2",
+        "resolve": "^1.5.0",
+        "rollup-pluginutils": "^2.0.1",
+        "style-inject": "^0.3.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13798,12 +13817,12 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "dev": true,
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000989",
-            "normalize-range": "0.1.2",
-            "num2fraction": "1.2.2",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1"
+            "browserslist": "^1.7.6",
+            "caniuse-db": "^1.0.30000634",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^5.2.16",
+            "postcss-value-parser": "^3.2.3"
           },
           "dependencies": {
             "chalk": {
@@ -13812,11 +13831,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -13833,10 +13852,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -13847,8 +13866,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000989",
-            "electron-to-chromium": "1.3.219"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "caniuse-api": {
@@ -13857,10 +13876,10 @@
           "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
           "dev": true,
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000989",
-            "lodash.memoize": "4.1.2",
-            "lodash.uniq": "4.5.0"
+            "browserslist": "^1.3.6",
+            "caniuse-db": "^1.0.30000529",
+            "lodash.memoize": "^4.1.2",
+            "lodash.uniq": "^4.5.0"
           }
         },
         "coa": {
@@ -13869,7 +13888,7 @@
           "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
           "dev": true,
           "requires": {
-            "q": "1.5.1"
+            "q": "^1.1.2"
           }
         },
         "cssnano": {
@@ -13878,38 +13897,38 @@
           "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
           "dev": true,
           "requires": {
-            "autoprefixer": "6.7.7",
-            "decamelize": "1.2.0",
-            "defined": "1.0.0",
-            "has": "1.0.3",
-            "object-assign": "4.1.1",
-            "postcss": "5.2.18",
-            "postcss-calc": "5.3.1",
-            "postcss-colormin": "2.2.2",
-            "postcss-convert-values": "2.6.1",
-            "postcss-discard-comments": "2.0.4",
-            "postcss-discard-duplicates": "2.1.0",
-            "postcss-discard-empty": "2.1.0",
-            "postcss-discard-overridden": "0.1.1",
-            "postcss-discard-unused": "2.2.3",
-            "postcss-filter-plugins": "2.0.3",
-            "postcss-merge-idents": "2.1.7",
-            "postcss-merge-longhand": "2.0.2",
-            "postcss-merge-rules": "2.1.2",
-            "postcss-minify-font-values": "1.0.5",
-            "postcss-minify-gradients": "1.0.5",
-            "postcss-minify-params": "1.2.2",
-            "postcss-minify-selectors": "2.1.1",
-            "postcss-normalize-charset": "1.1.1",
-            "postcss-normalize-url": "3.0.8",
-            "postcss-ordered-values": "2.2.3",
-            "postcss-reduce-idents": "2.4.0",
-            "postcss-reduce-initial": "1.0.1",
-            "postcss-reduce-transforms": "1.0.4",
-            "postcss-svgo": "2.1.6",
-            "postcss-unique-selectors": "2.0.2",
-            "postcss-value-parser": "3.3.1",
-            "postcss-zindex": "2.2.0"
+            "autoprefixer": "^6.3.1",
+            "decamelize": "^1.1.2",
+            "defined": "^1.0.0",
+            "has": "^1.0.1",
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.14",
+            "postcss-calc": "^5.2.0",
+            "postcss-colormin": "^2.1.8",
+            "postcss-convert-values": "^2.3.4",
+            "postcss-discard-comments": "^2.0.4",
+            "postcss-discard-duplicates": "^2.0.1",
+            "postcss-discard-empty": "^2.0.1",
+            "postcss-discard-overridden": "^0.1.1",
+            "postcss-discard-unused": "^2.2.1",
+            "postcss-filter-plugins": "^2.0.0",
+            "postcss-merge-idents": "^2.1.5",
+            "postcss-merge-longhand": "^2.0.1",
+            "postcss-merge-rules": "^2.0.3",
+            "postcss-minify-font-values": "^1.0.2",
+            "postcss-minify-gradients": "^1.0.1",
+            "postcss-minify-params": "^1.0.4",
+            "postcss-minify-selectors": "^2.0.4",
+            "postcss-normalize-charset": "^1.1.0",
+            "postcss-normalize-url": "^3.0.7",
+            "postcss-ordered-values": "^2.1.0",
+            "postcss-reduce-idents": "^2.2.2",
+            "postcss-reduce-initial": "^1.0.0",
+            "postcss-reduce-transforms": "^1.0.3",
+            "postcss-svgo": "^2.1.1",
+            "postcss-unique-selectors": "^2.0.2",
+            "postcss-value-parser": "^3.2.3",
+            "postcss-zindex": "^2.0.1"
           },
           "dependencies": {
             "chalk": {
@@ -13918,11 +13937,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -13939,10 +13958,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -13953,8 +13972,8 @@
           "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
           "dev": true,
           "requires": {
-            "clap": "1.2.3",
-            "source-map": "0.5.7"
+            "clap": "^1.0.9",
+            "source-map": "^0.5.3"
           }
         },
         "esprima": {
@@ -13975,7 +13994,7 @@
           "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
           "dev": true,
           "requires": {
-            "html-comment-regex": "1.1.2"
+            "html-comment-regex": "^1.1.0"
           }
         },
         "js-yaml": {
@@ -13984,8 +14003,8 @@
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
           }
         },
         "normalize-url": {
@@ -13994,10 +14013,10 @@
           "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "prepend-http": "1.0.4",
-            "query-string": "4.3.4",
-            "sort-keys": "1.1.2"
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
           }
         },
         "postcss": {
@@ -14006,9 +14025,9 @@
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.2",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
           },
           "dependencies": {
             "has-flag": {
@@ -14029,7 +14048,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -14040,9 +14059,9 @@
           "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "postcss-message-helpers": "2.0.0",
-            "reduce-css-calc": "1.3.0"
+            "postcss": "^5.0.2",
+            "postcss-message-helpers": "^2.0.0",
+            "reduce-css-calc": "^1.2.6"
           },
           "dependencies": {
             "chalk": {
@@ -14051,11 +14070,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14072,10 +14091,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14086,9 +14105,9 @@
           "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
           "dev": true,
           "requires": {
-            "colormin": "1.1.2",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1"
+            "colormin": "^1.0.5",
+            "postcss": "^5.0.13",
+            "postcss-value-parser": "^3.2.3"
           },
           "dependencies": {
             "chalk": {
@@ -14097,11 +14116,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14118,10 +14137,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14132,8 +14151,8 @@
           "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1"
+            "postcss": "^5.0.11",
+            "postcss-value-parser": "^3.1.2"
           },
           "dependencies": {
             "chalk": {
@@ -14142,11 +14161,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14163,10 +14182,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14177,7 +14196,7 @@
           "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.14"
           },
           "dependencies": {
             "chalk": {
@@ -14186,11 +14205,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14207,10 +14226,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14221,7 +14240,7 @@
           "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.4"
           },
           "dependencies": {
             "chalk": {
@@ -14230,11 +14249,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14251,10 +14270,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14265,7 +14284,7 @@
           "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.14"
           },
           "dependencies": {
             "chalk": {
@@ -14274,11 +14293,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14295,10 +14314,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14309,7 +14328,7 @@
           "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.16"
           },
           "dependencies": {
             "chalk": {
@@ -14318,11 +14337,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14339,10 +14358,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14353,7 +14372,7 @@
           "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.4"
           },
           "dependencies": {
             "chalk": {
@@ -14362,11 +14381,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14383,10 +14402,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14397,11 +14416,11 @@
           "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
           "dev": true,
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-api": "1.6.1",
-            "postcss": "5.2.18",
-            "postcss-selector-parser": "2.2.3",
-            "vendors": "1.0.3"
+            "browserslist": "^1.5.2",
+            "caniuse-api": "^1.5.2",
+            "postcss": "^5.0.4",
+            "postcss-selector-parser": "^2.2.2",
+            "vendors": "^1.0.0"
           },
           "dependencies": {
             "chalk": {
@@ -14410,11 +14429,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14431,10 +14450,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14445,9 +14464,9 @@
           "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1"
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.2"
           },
           "dependencies": {
             "chalk": {
@@ -14456,11 +14475,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14477,10 +14496,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14491,8 +14510,8 @@
           "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1"
+            "postcss": "^5.0.12",
+            "postcss-value-parser": "^3.3.0"
           },
           "dependencies": {
             "chalk": {
@@ -14501,11 +14520,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14522,10 +14541,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14536,10 +14555,10 @@
           "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
           "dev": true,
           "requires": {
-            "alphanum-sort": "1.0.2",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1",
-            "uniqs": "2.0.0"
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.2",
+            "postcss-value-parser": "^3.0.2",
+            "uniqs": "^2.0.0"
           },
           "dependencies": {
             "chalk": {
@@ -14548,11 +14567,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14569,10 +14588,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14583,10 +14602,10 @@
           "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
           "dev": true,
           "requires": {
-            "alphanum-sort": "1.0.2",
-            "has": "1.0.3",
-            "postcss": "5.2.18",
-            "postcss-selector-parser": "2.2.3"
+            "alphanum-sort": "^1.0.2",
+            "has": "^1.0.1",
+            "postcss": "^5.0.14",
+            "postcss-selector-parser": "^2.0.0"
           },
           "dependencies": {
             "chalk": {
@@ -14595,11 +14614,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14616,10 +14635,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14630,7 +14649,7 @@
           "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.5"
           },
           "dependencies": {
             "chalk": {
@@ -14639,11 +14658,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14660,10 +14679,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14674,10 +14693,10 @@
           "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
           "dev": true,
           "requires": {
-            "is-absolute-url": "2.1.0",
-            "normalize-url": "1.9.1",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1"
+            "is-absolute-url": "^2.0.0",
+            "normalize-url": "^1.4.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3"
           },
           "dependencies": {
             "chalk": {
@@ -14686,11 +14705,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14707,10 +14726,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14721,8 +14740,8 @@
           "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1"
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.1"
           },
           "dependencies": {
             "chalk": {
@@ -14731,11 +14750,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14752,10 +14771,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14766,7 +14785,7 @@
           "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.4"
           },
           "dependencies": {
             "chalk": {
@@ -14775,11 +14794,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14796,10 +14815,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14810,9 +14829,9 @@
           "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
           "dev": true,
           "requires": {
-            "has": "1.0.3",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1"
+            "has": "^1.0.1",
+            "postcss": "^5.0.8",
+            "postcss-value-parser": "^3.0.1"
           },
           "dependencies": {
             "chalk": {
@@ -14821,11 +14840,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14842,10 +14861,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14856,9 +14875,9 @@
           "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
           "dev": true,
           "requires": {
-            "flatten": "1.0.2",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "flatten": "^1.0.2",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         },
         "postcss-svgo": {
@@ -14867,10 +14886,10 @@
           "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
           "dev": true,
           "requires": {
-            "is-svg": "2.1.0",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.1",
-            "svgo": "0.7.2"
+            "is-svg": "^2.0.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3",
+            "svgo": "^0.7.0"
           },
           "dependencies": {
             "chalk": {
@@ -14879,11 +14898,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14900,10 +14919,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14914,9 +14933,9 @@
           "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
           "dev": true,
           "requires": {
-            "alphanum-sort": "1.0.2",
-            "postcss": "5.2.18",
-            "uniqs": "2.0.0"
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.4",
+            "uniqs": "^2.0.0"
           },
           "dependencies": {
             "chalk": {
@@ -14925,11 +14944,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -14946,10 +14965,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.5.1",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
               }
             }
           }
@@ -14972,7 +14991,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -14981,7 +15000,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "svgo": {
@@ -14990,13 +15009,13 @@
           "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
           "dev": true,
           "requires": {
-            "coa": "1.0.4",
-            "colors": "1.1.2",
-            "csso": "2.3.2",
-            "js-yaml": "3.7.0",
-            "mkdirp": "0.5.1",
-            "sax": "1.2.4",
-            "whet.extend": "0.9.9"
+            "coa": "~1.0.1",
+            "colors": "~1.1.2",
+            "csso": "~2.3.1",
+            "js-yaml": "~3.7.0",
+            "mkdirp": "~0.5.1",
+            "sax": "~1.2.1",
+            "whet.extend": "~0.9.9"
           }
         }
       }
@@ -15007,7 +15026,7 @@
       "integrity": "sha512-b+psdlXZOjmlnKmL6/YAkR8PR15VPcUNXdT35urBRJ8jE6UxHyb4HXeeN3qRZJbMJJaX1eRP72XwH6IvGFh5Jw==",
       "dev": true,
       "requires": {
-        "magic-string": "0.22.5"
+        "magic-string": "^0.22.4"
       },
       "dependencies": {
         "magic-string": {
@@ -15016,7 +15035,7 @@
           "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
           "dev": true,
           "requires": {
-            "vlq": "0.2.3"
+            "vlq": "^0.2.2"
           }
         }
       }
@@ -15027,10 +15046,10 @@
       "integrity": "sha512-6VsnWb4aBPcW++3IBMNPo4NLSheoaXh+itXk1OcaolLhYemoQFb7A9hVNocwa0j2BctdmPNFcP7UJ3g///VVaA==",
       "dev": true,
       "requires": {
-        "filesize": "3.6.1",
-        "lodash.foreach": "4.5.0",
-        "lodash.sumby": "4.6.0",
-        "module-details-from-path": "1.0.3"
+        "filesize": "^3.5.11",
+        "lodash.foreach": "^4.5.0",
+        "lodash.sumby": "^4.6.0",
+        "module-details-from-path": "^1.0.3"
       }
     },
     "rollup-plugin-terser": {
@@ -15039,10 +15058,10 @@
       "integrity": "sha512-Ed9zRD7OoCBnh0XGlEAJle5TCUsFXMLClwKzZWnS1zbNO4MelHjfCSdFZxCAdH70M40nhZ1nRrY2GZQJhSMcjA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "jest-worker": "23.2.0",
-        "serialize-javascript": "1.7.0",
-        "terser": "3.17.0"
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^23.2.0",
+        "serialize-javascript": "^1.5.0",
+        "terser": "^3.8.2"
       },
       "dependencies": {
         "jest-worker": {
@@ -15051,7 +15070,7 @@
           "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
           "dev": true,
           "requires": {
-            "merge-stream": "1.0.1"
+            "merge-stream": "^1.0.1"
           }
         }
       }
@@ -15074,7 +15093,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -15089,9 +15108,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.3"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "estree-walker": {
@@ -15106,7 +15125,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "extglob": {
@@ -15115,7 +15134,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "fs-extra": {
@@ -15124,9 +15143,9 @@
           "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.1",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "kind-of": {
@@ -15135,7 +15154,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "micromatch": {
@@ -15144,19 +15163,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "resolve": {
@@ -15165,7 +15184,7 @@
           "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.6"
+            "path-parse": "^1.0.5"
           }
         },
         "rollup-pluginutils": {
@@ -15174,8 +15193,8 @@
           "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
           "dev": true,
           "requires": {
-            "estree-walker": "0.5.2",
-            "micromatch": "2.3.11"
+            "estree-walker": "^0.5.2",
+            "micromatch": "^2.3.11"
           }
         },
         "tslib": {
@@ -15192,7 +15211,7 @@
       "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
       "dev": true,
       "requires": {
-        "estree-walker": "0.6.1"
+        "estree-walker": "^0.6.1"
       }
     },
     "rsvp": {
@@ -15213,7 +15232,7 @@
       "integrity": "sha512-USHm9quYNmJwFwhOnEuJohdnBhUOKV1mhL0koHSJMLJaesRX0nuDuzbWmtUBbUmXkwTalLtUBzDlEnU940BiQA==",
       "dev": true,
       "requires": {
-        "mri": "1.1.4"
+        "mri": "^1.1.0"
       }
     },
     "safe-buffer": {
@@ -15228,7 +15247,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -15243,15 +15262,15 @@
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
       "dev": true,
       "requires": {
-        "@cnakazawa/watch": "1.0.3",
-        "anymatch": "2.0.0",
-        "capture-exit": "2.0.0",
-        "exec-sh": "0.3.2",
-        "execa": "1.0.0",
-        "fb-watchman": "2.0.0",
-        "micromatch": "3.1.10",
-        "minimist": "1.2.0",
-        "walker": "1.0.7"
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^2.0.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
       }
     },
     "sax": {
@@ -15266,32 +15285,32 @@
       "integrity": "sha512-TqmRAsTFPq+hi0LjccUIHIknpW2wBPqVZWc/fVBBeeokuZ+wfGcP/Vo8nKci7VTHBl0D/EAu6gNvo343dKjWUA==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "6.3.2",
-        "@semantic-release/error": "2.2.0",
-        "@semantic-release/github": "5.5.5",
-        "@semantic-release/npm": "5.3.2",
-        "@semantic-release/release-notes-generator": "7.3.2",
-        "aggregate-error": "3.0.1",
-        "cosmiconfig": "5.2.1",
-        "debug": "4.1.1",
-        "env-ci": "4.5.1",
-        "execa": "3.2.0",
-        "figures": "3.1.0",
-        "find-versions": "3.1.0",
-        "get-stream": "5.1.0",
-        "git-log-parser": "1.2.0",
-        "hook-std": "2.0.0",
-        "hosted-git-info": "3.0.2",
-        "lodash": "4.17.15",
-        "marked": "0.7.0",
-        "marked-terminal": "3.3.0",
-        "p-locate": "4.1.0",
-        "p-reduce": "2.1.0",
-        "read-pkg-up": "7.0.0",
-        "resolve-from": "5.0.0",
-        "semver": "6.3.0",
-        "signale": "1.4.0",
-        "yargs": "14.2.0"
+        "@semantic-release/commit-analyzer": "^6.1.0",
+        "@semantic-release/error": "^2.2.0",
+        "@semantic-release/github": "^5.1.0",
+        "@semantic-release/npm": "^5.0.5",
+        "@semantic-release/release-notes-generator": "^7.1.2",
+        "aggregate-error": "^3.0.0",
+        "cosmiconfig": "^5.0.1",
+        "debug": "^4.0.0",
+        "env-ci": "^4.0.0",
+        "execa": "^3.2.0",
+        "figures": "^3.0.0",
+        "find-versions": "^3.0.0",
+        "get-stream": "^5.0.0",
+        "git-log-parser": "^1.2.0",
+        "hook-std": "^2.0.0",
+        "hosted-git-info": "^3.0.0",
+        "lodash": "^4.17.15",
+        "marked": "^0.7.0",
+        "marked-terminal": "^3.2.0",
+        "p-locate": "^4.0.0",
+        "p-reduce": "^2.0.0",
+        "read-pkg-up": "^7.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^6.0.0",
+        "signale": "^1.2.1",
+        "yargs": "^14.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -15300,9 +15319,9 @@
           "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.0",
-            "shebang-command": "2.0.0",
-            "which": "2.0.1"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "debug": {
@@ -15311,7 +15330,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "execa": {
@@ -15320,16 +15339,16 @@
           "integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
           "dev": true,
           "requires": {
-            "cross-spawn": "7.0.1",
-            "get-stream": "5.1.0",
-            "human-signals": "1.1.1",
-            "is-stream": "2.0.0",
-            "merge-stream": "2.0.0",
-            "npm-run-path": "4.0.0",
-            "onetime": "5.1.0",
-            "p-finally": "2.0.1",
-            "signal-exit": "3.0.2",
-            "strip-final-newline": "2.0.0"
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "figures": {
@@ -15338,7 +15357,7 @@
           "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "find-up": {
@@ -15347,8 +15366,8 @@
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "5.0.0",
-            "path-exists": "4.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "get-stream": {
@@ -15357,7 +15376,7 @@
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "hosted-git-info": {
@@ -15366,7 +15385,7 @@
           "integrity": "sha512-ezZMWtHXm7Eb7Rq4Mwnx2vs79WUx2QmRg3+ZqeGroKzfDO+EprOcgRPYghsOP9JuYBfK18VojmRTGCg8Ma+ktw==",
           "dev": true,
           "requires": {
-            "lru-cache": "5.1.1"
+            "lru-cache": "^5.1.1"
           }
         },
         "is-stream": {
@@ -15381,7 +15400,7 @@
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
-            "p-locate": "4.1.0"
+            "p-locate": "^4.1.0"
           }
         },
         "merge-stream": {
@@ -15402,7 +15421,7 @@
           "integrity": "sha512-8eyAOAH+bYXFPSnNnKr3J+yoybe8O87Is5rtAQ8qRczJz1ajcsjg8l2oZqP+Ppx15Ii3S1vUTjQN2h4YO2tWWQ==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.0"
+            "path-key": "^3.0.0"
           }
         },
         "p-finally": {
@@ -15417,7 +15436,7 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "2.2.1"
+            "p-limit": "^2.2.0"
           }
         },
         "p-reduce": {
@@ -15432,10 +15451,10 @@
           "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "7.5.5",
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2",
-            "lines-and-columns": "1.1.6"
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
           }
         },
         "path-exists": {
@@ -15456,10 +15475,10 @@
           "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
           "dev": true,
           "requires": {
-            "@types/normalize-package-data": "2.4.0",
-            "normalize-package-data": "2.5.0",
-            "parse-json": "5.0.0",
-            "type-fest": "0.6.0"
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
           },
           "dependencies": {
             "type-fest": {
@@ -15476,9 +15495,9 @@
           "integrity": "sha512-t2ODkS/vTTcRlKwZiZsaLGb5iwfx9Urp924aGzVyboU6+7Z2i6eGr/G1Z4mjvwLLQV3uFOBKobNRGM3ux2PD/w==",
           "dev": true,
           "requires": {
-            "find-up": "4.1.0",
-            "read-pkg": "5.2.0",
-            "type-fest": "0.8.1"
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
           }
         },
         "resolve-from": {
@@ -15499,7 +15518,7 @@
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
-            "shebang-regex": "3.0.0"
+            "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
@@ -15514,9 +15533,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "type-fest": {
@@ -15531,7 +15550,7 @@
           "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "yargs": {
@@ -15540,17 +15559,17 @@
           "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
           "dev": true,
           "requires": {
-            "cliui": "5.0.0",
-            "decamelize": "1.2.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "2.0.5",
-            "require-directory": "2.1.1",
-            "require-main-filename": "2.0.0",
-            "set-blocking": "2.0.0",
-            "string-width": "3.1.0",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "15.0.0"
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -15559,7 +15578,7 @@
               "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "dev": true,
               "requires": {
-                "locate-path": "3.0.0"
+                "locate-path": "^3.0.0"
               }
             },
             "locate-path": {
@@ -15568,8 +15587,8 @@
               "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "dev": true,
               "requires": {
-                "p-locate": "3.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
               }
             },
             "p-locate": {
@@ -15578,7 +15597,7 @@
               "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "dev": true,
               "requires": {
-                "p-limit": "2.2.1"
+                "p-limit": "^2.0.0"
               }
             },
             "path-exists": {
@@ -15595,8 +15614,8 @@
           "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -15631,10 +15650,10 @@
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -15643,7 +15662,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -15654,7 +15673,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -15681,9 +15700,9 @@
       "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "figures": "2.0.0",
-        "pkg-conf": "2.1.0"
+        "chalk": "^2.3.2",
+        "figures": "^2.0.0",
+        "pkg-conf": "^2.1.0"
       },
       "dependencies": {
         "figures": {
@@ -15692,7 +15711,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         }
       }
@@ -15709,9 +15728,9 @@
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "dev": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "simple-swizzle": {
@@ -15720,7 +15739,7 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.3.2"
+        "is-arrayish": "^0.3.1"
       },
       "dependencies": {
         "is-arrayish": {
@@ -15749,14 +15768,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.1"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -15765,7 +15784,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -15774,7 +15793,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "source-map": {
@@ -15791,9 +15810,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -15802,7 +15821,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -15811,7 +15830,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -15820,7 +15839,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -15829,9 +15848,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -15842,7 +15861,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -15851,7 +15870,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -15862,7 +15881,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-map": {
@@ -15877,11 +15896,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.2",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -15890,8 +15909,8 @@
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "source-map-url": {
@@ -15918,8 +15937,8 @@
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.5"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -15934,8 +15953,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.5"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -15950,7 +15969,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -15959,7 +15978,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "split2": {
@@ -15968,7 +15987,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "2.0.5"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -15983,15 +16002,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stable": {
@@ -16012,8 +16031,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -16022,7 +16041,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -16039,8 +16058,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.6"
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
       }
     },
     "strict-uri-encode": {
@@ -16061,8 +16080,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -16077,7 +16096,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -16088,8 +16107,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -16104,7 +16123,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -16115,7 +16134,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -16124,7 +16143,7 @@
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "4.1.0"
+        "ansi-regex": "^4.1.0"
       }
     },
     "strip-bom": {
@@ -16169,9 +16188,9 @@
       "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
       "dev": true,
       "requires": {
-        "browserslist": "4.6.6",
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "3.1.1"
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -16180,9 +16199,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -16193,7 +16212,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "supports-hyperlinks": {
@@ -16202,8 +16221,8 @@
       "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0",
-        "supports-color": "5.5.0"
+        "has-flag": "^2.0.0",
+        "supports-color": "^5.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -16220,19 +16239,19 @@
       "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "coa": "2.0.2",
-        "css-select": "2.0.2",
-        "css-select-base-adapter": "0.1.1",
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
         "css-tree": "1.0.0-alpha.33",
-        "csso": "3.5.1",
-        "js-yaml": "3.13.1",
-        "mkdirp": "0.5.1",
-        "object.values": "1.1.0",
-        "sax": "1.2.4",
-        "stable": "0.1.8",
-        "unquote": "1.1.1",
-        "util.promisify": "1.0.0"
+        "csso": "^3.5.1",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
       }
     },
     "symbol-tree": {
@@ -16247,10 +16266,10 @@
       "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "dev": true,
       "requires": {
-        "chownr": "1.1.2",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.6.2"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       },
       "dependencies": {
         "pump": {
@@ -16259,8 +16278,8 @@
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -16271,13 +16290,13 @@
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.2.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.2"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
       }
     },
     "teeny-request": {
@@ -16286,9 +16305,9 @@
       "integrity": "sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "2.2.4",
-        "node-fetch": "2.6.0",
-        "uuid": "3.3.3"
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.2.0",
+        "uuid": "^3.3.2"
       }
     },
     "temp-dir": {
@@ -16303,9 +16322,9 @@
       "integrity": "sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==",
       "dev": true,
       "requires": {
-        "temp-dir": "1.0.0",
-        "type-fest": "0.3.1",
-        "unique-string": "1.0.0"
+        "temp-dir": "^1.0.0",
+        "type-fest": "^0.3.1",
+        "unique-string": "^1.0.0"
       },
       "dependencies": {
         "type-fest": {
@@ -16322,9 +16341,9 @@
       "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
       "dev": true,
       "requires": {
-        "commander": "2.20.0",
-        "source-map": "0.6.1",
-        "source-map-support": "0.5.13"
+        "commander": "^2.19.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.10"
       }
     },
     "test-exclude": {
@@ -16333,10 +16352,10 @@
       "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
       "dev": true,
       "requires": {
-        "glob": "7.1.4",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "4.0.0",
-        "require-main-filename": "2.0.0"
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
       }
     },
     "text-extensions": {
@@ -16363,8 +16382,8 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.2"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
     },
     "timsort": {
@@ -16379,8 +16398,8 @@
       "integrity": "sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==",
       "dev": true,
       "requires": {
-        "globalyzer": "0.1.4",
-        "globrex": "0.1.2"
+        "globalyzer": "^0.1.0",
+        "globrex": "^0.1.1"
       }
     },
     "tmpl": {
@@ -16407,7 +16426,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -16416,7 +16435,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -16427,10 +16446,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -16439,8 +16458,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -16449,8 +16468,8 @@
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "1.3.0",
-        "punycode": "2.1.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tr46": {
@@ -16459,7 +16478,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "traverse": {
@@ -16492,15 +16511,15 @@
       "integrity": "sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==",
       "dev": true,
       "requires": {
-        "bs-logger": "0.2.6",
-        "buffer-from": "1.1.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json5": "2.1.0",
-        "make-error": "1.3.5",
-        "mkdirp": "0.5.1",
-        "resolve": "1.12.0",
-        "semver": "5.7.0",
-        "yargs-parser": "10.1.0"
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "json5": "2.x",
+        "make-error": "1.x",
+        "mkdirp": "0.x",
+        "resolve": "1.x",
+        "semver": "^5.5",
+        "yargs-parser": "10.x"
       },
       "dependencies": {
         "camelcase": {
@@ -16515,7 +16534,7 @@
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -16532,19 +16551,19 @@
       "integrity": "sha512-1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "builtin-modules": "1.1.1",
-        "chalk": "2.4.2",
-        "commander": "2.20.0",
-        "diff": "3.5.0",
-        "glob": "7.1.4",
-        "js-yaml": "3.13.1",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "resolve": "1.12.0",
-        "semver": "5.7.0",
-        "tslib": "1.10.0",
-        "tsutils": "2.29.0"
+        "@babel/code-frame": "^7.0.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.29.0"
       },
       "dependencies": {
         "builtin-modules": {
@@ -16569,7 +16588,7 @@
       "requires": {
         "doctrine": "0.7.2",
         "tslib": "1.9.0",
-        "tsutils": "3.17.1"
+        "tsutils": "^3.0.0"
       },
       "dependencies": {
         "tslib": {
@@ -16584,7 +16603,7 @@
           "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
           "dev": true,
           "requires": {
-            "tslib": "1.9.0"
+            "tslib": "^1.8.1"
           }
         }
       }
@@ -16595,7 +16614,7 @@
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.8.1"
       }
     },
     "tunnel-agent": {
@@ -16604,7 +16623,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -16619,7 +16638,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-fest": {
@@ -16641,8 +16660,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.20.0",
-        "source-map": "0.6.1"
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
       }
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -16657,8 +16676,8 @@
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "1.0.4",
-        "unicode-property-aliases-ecmascript": "1.0.5"
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -16679,10 +16698,10 @@
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "2.0.1"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {
@@ -16703,7 +16722,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "universal-user-agent": {
@@ -16712,7 +16731,7 @@
       "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
       "dev": true,
       "requires": {
-        "os-name": "3.1.0"
+        "os-name": "^3.1.0"
       }
     },
     "universalify": {
@@ -16733,8 +16752,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -16743,9 +16762,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -16773,7 +16792,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -16812,8 +16831,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "uuid": {
@@ -16828,8 +16847,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.1.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vendors": {
@@ -16844,9 +16863,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vlq": {
@@ -16861,7 +16880,7 @@
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "0.1.3"
+        "browser-process-hrtime": "^0.1.2"
       }
     },
     "walker": {
@@ -16870,7 +16889,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "webidl-conversions": {
@@ -16900,9 +16919,9 @@
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "whet.extend": {
@@ -16917,7 +16936,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -16938,7 +16957,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "windows-release": {
@@ -16947,7 +16966,7 @@
       "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
       "dev": true,
       "requires": {
-        "execa": "1.0.0"
+        "execa": "^1.0.0"
       }
     },
     "wordwrap": {
@@ -16962,9 +16981,9 @@
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "string-width": {
@@ -16973,9 +16992,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         }
       }
@@ -16992,9 +17011,9 @@
       "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.1",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {
@@ -17003,7 +17022,7 @@
       "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.1"
+        "async-limiter": "~1.0.0"
       }
     },
     "xml-name-validator": {
@@ -17036,16 +17055,16 @@
       "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
       "dev": true,
       "requires": {
-        "cliui": "5.0.0",
-        "find-up": "3.0.0",
-        "get-caller-file": "2.0.5",
-        "require-directory": "2.1.1",
-        "require-main-filename": "2.0.0",
-        "set-blocking": "2.0.0",
-        "string-width": "3.1.0",
-        "which-module": "2.0.0",
-        "y18n": "4.0.0",
-        "yargs-parser": "13.1.1"
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.1"
       },
       "dependencies": {
         "string-width": {
@@ -17054,9 +17073,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         }
       }
@@ -17067,8 +17086,8 @@
       "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {
-        "camelcase": "5.3.1",
-        "decamelize": "1.2.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     }
   }

--- a/src/__tests__/resolver-test.ts
+++ b/src/__tests__/resolver-test.ts
@@ -201,6 +201,16 @@ describe('resolver', () => {
       })
     })
 
+    it('throws on null document', async () => {
+      const nullRes = new Resolver({
+        nuller: () => Promise.resolve(null)
+      })
+
+      await expect(nullRes.resolve('did:nuller:asdfghjk')).rejects.toEqual(
+        new Error('resolver returned null for did:nuller:asdfghjk')
+      )
+    })
+
     describe('caching', () => {
       describe('default', () => {
         it('should not cache', async () => {
@@ -304,6 +314,24 @@ describe('resolver', () => {
             }
           ]
         })
+        return expect(mockmethod).toBeCalledTimes(2)
+      })
+
+      it('should not cache null docs', async () => {
+        mockmethod = jest.fn().mockReturnValue(null)
+        resolver = new Resolver(
+          {
+            mock: mockmethod
+          },
+          true
+        )
+
+        await expect(resolver.resolve('did:mock:abcdef')).rejects.toEqual(
+          new Error('resolver returned null for did:mock:abcdef')
+        )
+        await expect(resolver.resolve('did:mock:abcdef')).rejects.toEqual(
+          new Error('resolver returned null for did:mock:abcdef')
+        )
         return expect(mockmethod).toBeCalledTimes(2)
       })
     })


### PR DESCRIPTION
BREAKING CHANGE: The `Resolver.resolve()` will now `Promise.reject()` if the DID document returned by the registered method is `null`.