### PR TITLE
Updated publicKey attribute 'owner' to 'controller'

### DIFF
--- a/src/__tests__/resolver-test.ts
+++ b/src/__tests__/resolver-test.ts
@@ -152,7 +152,7 @@ describe('resolver', () => {
       publicKey: [
         {
           id: 'owner',
-          owner: '1234',
+          controller: '1234',
           type: 'xyz'
         }
       ]
@@ -166,7 +166,7 @@ describe('resolver', () => {
           publicKey: [
             {
               id: 'owner',
-              owner: '1234',
+              controller: '1234',
               type: 'xyz'
             }
           ]
@@ -194,7 +194,7 @@ describe('resolver', () => {
         publicKey: [
           {
             id: 'owner',
-            owner: '1234',
+            controller: '1234',
             type: 'xyz'
           }
         ]
@@ -225,7 +225,7 @@ describe('resolver', () => {
             publicKey: [
               {
                 id: 'owner',
-                owner: '1234',
+                controller: '1234',
                 type: 'xyz'
               }
             ]
@@ -236,7 +236,7 @@ describe('resolver', () => {
             publicKey: [
               {
                 id: 'owner',
-                owner: '1234',
+                controller: '1234',
                 type: 'xyz'
               }
             ]
@@ -262,7 +262,7 @@ describe('resolver', () => {
           publicKey: [
             {
               id: 'owner',
-              owner: '1234',
+              controller: '1234',
               type: 'xyz'
             }
           ]
@@ -273,7 +273,7 @@ describe('resolver', () => {
           publicKey: [
             {
               id: 'owner',
-              owner: '1234',
+              controller: '1234',
               type: 'xyz'
             }
           ]
@@ -296,7 +296,7 @@ describe('resolver', () => {
           publicKey: [
             {
               id: 'owner',
-              owner: '1234',
+              controller: '1234',
               type: 'xyz'
             }
           ]
@@ -309,7 +309,7 @@ describe('resolver', () => {
           publicKey: [
             {
               id: 'owner',
-              owner: '1234',
+              controller: '1234',
               type: 'xyz'
             }
           ]

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -34,7 +34,7 @@ export interface ServiceEndpoint {
 export interface PublicKey {
   id: string
   type: string
-  owner: string
+  controller: string
   ethereumAddress?: string
   publicKeyBase64?: string
   publicKeyBase58?: string


### PR DESCRIPTION
According to the latest W3C DID spec, a `publicKey` property MUST have `id`, `type`, and `controller`. (https://www.w3.org/TR/did-core/#public-keys)

As far as I know, `owner` property is legacy named before the spec was written. #54 

So I changed the `owner` to `controller` to comply with the spec.