### PR TITLE
hotfix: fix DIDDocument type!

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -60,7 +60,7 @@ export type DIDDocument = {
    */
   publicKey?: VerificationMethod[]
 } & {
-  [x in KeyCapabilitySection]: (string | VerificationMethod)[]
+  [x in KeyCapabilitySection]?: (string | VerificationMethod)[]
 }
 
 export interface ServiceEndpoint {


### PR DESCRIPTION
Properties in the `DIDDocument` type changed from being optional to required in [this commit](https://github.com/decentralized-identity/did-resolver/commit/34020941734e2e9d2fb531793c6a82242e26953e).

This was released as a PATCH version, while it should be a MAJOR version.

This is a bug in the types since these properties should be optional. This PR makes them optional again. This should be released as a PATCH so that the previous release is unbroken for everyone that relies on the `DIDDocument` type.