### PR TITLE
feat(parser): support per-method parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,82 @@ import MyMethod from 'mymethod-did-resolver'
 const myResolver = MyMethod.getResolver()
 const resolver = new DIDResolver(myResolver)
 ```
+
+### Per-Method Parsing
+
+If your method has special syntax constraints beyond the base DID Core v1.0 spec, you can attach a method-specific parser to your resolver. This allows stricter syntax validation without duplicate parsing work.
+
+**Architecture:** Method-specific parsers receive a DID Core v1.0 compliant `ParsedDID` result from the global parser and only check method-specific syntax constraints. This ensures all DIDs pass DID Core v1.0 parsing first, then method-specific syntax rules. The parser is part of the resolver enhancement — both are exported together from `getResolver()`.
+
+```js
+export function getResolver() {
+  async function resolve(
+    did: string,
+    parsed: ParsedDID,
+    didResolver: Resolver,
+    options: DIDResolutionOptions
+  ): Promise<DIDDocument> {
+    console.log(parsed)
+    // {method: 'mymethod', id: 'abcdefg', did: 'did:mymethod:abcdefg/some/path#fragment=123', path: '/some/path', fragment: 'fragment=123'}
+    
+    const didDoc = ... // lookup doc
+    // If you need to lookup another did as part of resolving this did document, the primary DIDResolver object is passed in as well
+    const parentDID = await didResolver.resolve(...)
+    
+    // Return the DIDResolutionResult object
+    return {
+      didResolutionMetadata: { contentType: 'application/did+ld+json' },
+      didDocument: didDoc,
+      didDocumentMetadata: { ... }
+    }
+  }
+
+  function parser(parsed: ParsedDID): ParsedDID | null {
+    // Receive DID Core v1.0 compliant ParsedDID from global parser
+    // Only add method-specific syntax constraints
+    
+    // Example: enforce minimum id length for this method
+    if (parsed.id.length < 5) {
+      return null  // Reject with invalidDid error
+    }
+    
+    // Can refine/enrich the parsed result if needed
+    return {
+      ...parsed,
+      methodSpecificField: 'value'
+    }
+  }
+
+  // Attach parser to resolver — this is required for the parser to be used
+  resolve.parser = parser
+
+  return { myMethod: resolve }
+}
+```
+
+Consumers register the resolver normally — the parser is part of it:
+
+```js
+import { Resolver } from 'did-resolver'
+import MyMethod from 'mymethod-did-resolver'
+
+// For a single method
+const resolver = new Resolver(MyMethod.getResolver())
+
+// For multiple methods, flatten them together
+import OtherMethod from 'other-did-resolver'
+const resolver = new Resolver({
+  ...MyMethod.getResolver(),
+  ...OtherMethod.getResolver(),
+})
+```
+
+**Benefits:**
+
+- Method libraries control their own parse→resolve pipeline as a cohesive unit
+- Parser is discovered automatically via the resolver's `.parser` property
+- No duplicate parsing work
+- All DIDs guaranteed to pass DID Core v1.0 parsing first
+- Method parsers only implement method-specific syntax constraints
+- Parsers can refine/enrich the parsed result if needed
+- If parser returns `null`, resolution fails with `invalidDid` error

--- a/README.md
+++ b/README.md
@@ -86,17 +86,16 @@ const doc = await resolver.resolve('did:ethr:0xF3beAC30C498D9E26865F34fCAa57dBB9
 
 ## Caching
 
-Resolving DID Documents can be expensive. It is in most cases best to cache DID documents. Caching has to be
-specifically enabled using the `cache` parameter
+Resolving DID Documents can be expensive. It is in most cases best to cache DID documents. Caching is controlled via the `cache` option, which accepts a boolean value or a custom `DIDCache` function.
 
-The built-in cache uses a Map, but does not have an automatic TTL, so entries don't expire. This is fine in most web,
-mobile and serverless contexts. If you run a long-running process you may want to use an existing configurable caching
-system.
+### Built-in caching
 
-The built-in Cache can be enabled by passing in a `true` value to the constructor:
+The built-in cache uses a `Map` and does not have an automatic TTL, so entries don't expire. This is fine in most web, mobile and serverless contexts. If you run a long-running process, consider using a custom cache with expiration.
+
+Enable the built-in cache by passing `cache: true` to the constructor:
 
 ```js
-const resolver = new DIDResolver({
+const resolver = new Resolver({
   ethr,
   web
 }, {
@@ -104,21 +103,49 @@ const resolver = new DIDResolver({
 })
 ```
 
-Here is an example using `js-cache` which has not been tested.
+### Disabling cache
+
+To disable caching entirely, pass `cache: false`:
 
 ```js
-var cache = require('js-cache')
-const customCache : DIDCache = (parsed, resolve) => {
-  // DID spec requires to not cache if no-cache param is set
-  if (parsed.params && parsed.params['no-cache'] === 'true') return await resolve()
+const resolver = new Resolver({
+  ethr,
+  web
+}, {
+  cache: false
+})
+```
+
+### Per-call cache control
+
+You can override the global cache setting on a per-call basis using the `cache` option in `DIDResolutionOptions`:
+
+```js
+// Global cache enabled, but disable for this specific resolution
+const doc = await resolver.resolve('did:ethr:0xabcd...', { cache: false })
+
+// Global cache disabled, but enable for this specific resolution
+const doc = await resolver.resolve('did:ethr:0xabcd...', { cache: true })
+```
+
+### Custom cache implementation
+
+For advanced use cases, implement a custom `DIDCache` function. It receives the parsed DID, a resolve function, and optional resolution options:
+
+```js
+const customCache: DIDCache = async (parsed, resolve, options) => {
+  // Respect per-call cache control
+  if (options?.cache === false) return await resolve()
+  
   const cached = cache.get(parsed.didUrl)
   if (cached !== undefined) return cached
+  
   const doc = await resolve()
-  cache.set(parsed, doc, 60000)
+  cache.set(parsed.didUrl, doc, 60000) // 60s TTL
   return doc
 }
 
-const resolver = new DIDResolver({
+const resolver = new Resolver({
   ethr,
   web
 }, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "did-resolver",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Resolve DID documents",
   "source": "src/resolver.ts",
   "main": "./lib/resolver.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "did-resolver",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Resolve DID documents",
   "source": "src/resolver.ts",
   "main": "./lib/resolver.cjs",

--- a/src/__tests__/resolver.test.ts
+++ b/src/__tests__/resolver.test.ts
@@ -497,7 +497,7 @@ describe('resolver', () => {
         return expect(mockmethod).toBeCalledTimes(1)
       })
 
-      it('should respect no-cache', async () => {
+      it('should cache identical resolutions with cache: true', async () => {
         mockmethod = vi.fn().mockReturnValue(mockReturn)
         resolver = new Resolver(
           {
@@ -506,35 +506,23 @@ describe('resolver', () => {
           { cache: true }
         )
 
-        await expect(resolver.resolve('did:mock:abcdef')).resolves.toEqual({
-          didResolutionMetadata: { contentType: 'application/did+json' },
-          didDocument: {
-            id: 'did:mock:abcdef',
-            verificationMethod: [
-              {
-                id: 'owner',
-                controller: '1234',
-                type: 'xyz',
-              },
-            ],
+        await resolver.resolve('did:mock:abcdef')
+        await resolver.resolve('did:mock:abcdef')
+        return expect(mockmethod).toBeCalledTimes(1) // Only calls once when cache: true
+      })
+
+      it('should not cache with cache: false', async () => {
+        mockmethod = vi.fn().mockReturnValue(mockReturn)
+        resolver = new Resolver(
+          {
+            mock: mockmethod,
           },
-          didDocumentMetadata: {},
-        })
-        await expect(resolver.resolve('did:mock:abcdef;no-cache=true')).resolves.toEqual({
-          didResolutionMetadata: { contentType: 'application/did+json' },
-          didDocument: {
-            id: 'did:mock:abcdef',
-            verificationMethod: [
-              {
-                id: 'owner',
-                controller: '1234',
-                type: 'xyz',
-              },
-            ],
-          },
-          didDocumentMetadata: {},
-        })
-        return expect(mockmethod).toBeCalledTimes(2)
+          { cache: false }
+        )
+
+        await resolver.resolve('did:mock:abcdef')
+        await resolver.resolve('did:mock:abcdef')
+        return expect(mockmethod).toBeCalledTimes(2) // Calls twice when cache: false
       })
 
       it('should not cache with different params', async () => {
@@ -602,6 +590,34 @@ describe('resolver', () => {
           didDocument: null,
           didDocumentMetadata: {},
         })
+        return expect(mockmethod).toBeCalledTimes(2)
+      })
+
+      it('should bypass cache with cache: false option', async () => {
+        mockmethod = vi.fn().mockReturnValue(mockReturn)
+        resolver = new Resolver(
+          {
+            mock: mockmethod,
+          },
+          { cache: true }
+        )
+
+        await resolver.resolve('did:mock:abcdef')
+        await resolver.resolve('did:mock:abcdef', { cache: false })
+        return expect(mockmethod).toBeCalledTimes(2)
+      })
+
+      it('should safely ignore cache: false when global cache: false', async () => {
+        mockmethod = vi.fn().mockReturnValue(mockReturn)
+        resolver = new Resolver(
+          {
+            mock: mockmethod,
+          },
+          { cache: false }
+        )
+
+        await resolver.resolve('did:mock:abcdef')
+        await resolver.resolve('did:mock:abcdef', { cache: false })
         return expect(mockmethod).toBeCalledTimes(2)
       })
     })

--- a/src/__tests__/resolver.test.ts
+++ b/src/__tests__/resolver.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { vi, describe, it, expect, beforeAll, Mock } from 'vitest'
-import { Resolver, parse, DIDResolver, DIDResolutionResult } from '../resolver'
+import { Resolver, parse, DIDResolver, DIDParser, ParsedDID, DIDResolutionResult } from '../resolver'
 
 describe('resolver', () => {
   describe('parse()', () => {
@@ -618,6 +618,78 @@ describe('resolver', () => {
         await resolver.resolve('did:mock:abcdef')
         await resolver.resolve('did:mock:abcdef', { cache: false })
         return expect(mockmethod).toBeCalledTimes(2)
+      })
+    })
+
+    describe('per-method parsers', () => {
+      it('uses resolver-attached parser for validation', async () => {
+        const customParser: DIDParser = (parsed: ParsedDID) => {
+          // Only accept specific id format for this method
+          if (parsed.id.length < 5) {
+            return null
+          }
+          // Refine the parsed result if needed
+          return {
+            ...parsed,
+            id: `refined-${parsed.id}`
+          }
+        }
+
+        const customResolver: DIDResolver = async (did: string, parsed: ParsedDID): Promise<DIDResolutionResult> => ({
+          didResolutionMetadata: { contentType: 'application/did+json' },
+          didDocument: { id: parsed.id },
+          didDocumentMetadata: {}
+        })
+
+        // Attach parser to resolver
+        customResolver.parser = customParser
+
+        const resolver = new Resolver({
+          custom: customResolver
+        })
+
+        const result = await resolver.resolve('did:custom:abcdef')
+        return expect(result.didDocument?.id).toBe('refined-abcdef')
+      })
+
+      it('rejects invalid DID when resolver parser returns null', async () => {
+        const customParser: DIDParser = (parsed: ParsedDID) => {
+          // Only accept ids with length >= 5
+          if (parsed.id.length < 5) {
+            return null
+          }
+          return parsed
+        }
+
+        const customResolver: DIDResolver = async (): Promise<DIDResolutionResult> => ({
+          didResolutionMetadata: {},
+          didDocument: {},
+          didDocumentMetadata: {}
+        })
+
+        customResolver.parser = customParser
+
+        const resolver = new Resolver({
+          custom: customResolver
+        })
+
+        const result = await resolver.resolve('did:custom:abc')
+        return expect(result.didResolutionMetadata.error).toBe('invalidDid')
+      })
+
+      it('skips custom parser if resolver does not have one', async () => {
+        const customResolver: DIDResolver = async (did: string, parsed: ParsedDID): Promise<DIDResolutionResult> => ({
+          didResolutionMetadata: {},
+          didDocument: { id: parsed.id },
+          didDocumentMetadata: {}
+        })
+
+        const resolver = new Resolver({
+          custom: customResolver
+        })
+
+        const result = await resolver.resolve('did:custom:xyz')
+        return expect(result.didDocument?.id).toBe('xyz')
       })
     })
   })

--- a/src/__tests__/resolver.test.ts
+++ b/src/__tests__/resolver.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { vi, describe, it, expect, beforeAll } from 'vitest'
-import { Resolver, parse, DIDResolutionResult } from '../resolver'
+import { Resolver, parse, parseStrict, DIDResolutionResult } from '../resolver'
 
 describe('resolver', () => {
   describe('parse()', () => {
@@ -138,6 +138,167 @@ describe('resolver', () => {
       expect(parse('did:method:%1233%Ay')).toEqual(null)
       expect(parse('did:CAP:id')).toEqual(null)
       expect(parse('did:method:id::anotherid%r9')).toEqual(null)
+    })
+  })
+
+  describe('parseStrict()', () => {
+    it('returns parts', () => {
+      expect(parseStrict('did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX')).toEqual({
+        method: 'uport',
+        id: '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
+        did: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
+        didUrl: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
+      })
+      expect(parseStrict('did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX/some/path')).toEqual({
+        method: 'uport',
+        id: '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
+        did: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
+        didUrl: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX/some/path',
+        path: '/some/path',
+      })
+      expect(parseStrict('did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX#fragment=123')).toEqual({
+        method: 'uport',
+        id: '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
+        did: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
+        didUrl: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX#fragment=123',
+        fragment: 'fragment=123',
+      })
+      expect(parseStrict('did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX/some/path#fragment=123')).toEqual({
+        method: 'uport',
+        id: '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
+        did: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
+        didUrl: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX/some/path#fragment=123',
+        path: '/some/path',
+        fragment: 'fragment=123',
+      })
+      expect(parseStrict('did:nacl:Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI')).toEqual({
+        method: 'nacl',
+        id: 'Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI',
+        did: 'did:nacl:Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI',
+        didUrl: 'did:nacl:Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI',
+      })
+      expect(parseStrict('did:web:example.com%3A8443')).toEqual({
+        method: 'web',
+        id: 'example.com%3A8443',
+        didUrl: 'did:web:example.com%3A8443',
+        did: 'did:web:example.com%3A8443',
+      })
+      expect(parseStrict('did:web:example.com:path:some%2Bsubpath')).toEqual({
+        method: 'web',
+        id: 'example.com:path:some%2Bsubpath',
+        didUrl: 'did:web:example.com:path:some%2Bsubpath',
+        did: 'did:web:example.com:path:some%2Bsubpath',
+      })
+      expect(parseStrict('did:123:test::test2')).toEqual({
+        method: '123',
+        id: 'test::test2',
+        didUrl: 'did:123:test::test2',
+        did: 'did:123:test::test2',
+      })
+      expect(parseStrict('did:method:%12%AF')).toEqual({
+        method: 'method',
+        id: '%12%AF',
+        didUrl: 'did:method:%12%AF',
+        did: 'did:method:%12%AF',
+      })
+    })
+
+    it('returns null if non compliant', () => {
+      expect(parseStrict('')).toEqual(null)
+      expect(parseStrict('did:')).toEqual(null)
+      expect(parseStrict('did:uport')).toEqual(null)
+      expect(parseStrict('did:uport:')).toEqual(null)
+      expect(parseStrict('did:uport:1234_12313***')).toEqual(null)
+      expect(parseStrict('2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX')).toEqual(null)
+      expect(parseStrict('did:method:%12%1')).toEqual(null)
+      expect(parseStrict('did:method:%1233%Ay')).toEqual(null)
+      expect(parseStrict('did:CAP:id')).toEqual(null)
+      expect(parseStrict('did:method:id::anotherid%r9')).toEqual(null)
+    })
+
+    it('handles query and fragment correctly', () => {
+      expect(parseStrict('did:x:y?key=value')).toEqual({
+        method: 'x',
+        id: 'y',
+        did: 'did:x:y',
+        didUrl: 'did:x:y?key=value',
+        query: 'key=value',
+      })
+      expect(parseStrict('did:x:y?')).toEqual({
+        method: 'x',
+        id: 'y',
+        did: 'did:x:y',
+        didUrl: 'did:x:y?',
+        query: '',
+      })
+      expect(parseStrict('did:x:y#')).toEqual({
+        method: 'x',
+        id: 'y',
+        did: 'did:x:y',
+        didUrl: 'did:x:y#',
+        fragment: '',
+      })
+      expect(parseStrict('did:x:y?query#fragment')).toEqual({
+        method: 'x',
+        id: 'y',
+        did: 'did:x:y',
+        didUrl: 'did:x:y?query#fragment',
+        query: 'query',
+        fragment: 'fragment',
+      })
+    })
+
+    it('supports RFC 3986 path characters', () => {
+      expect(parseStrict('did:x:y/path~with-tilde')).toEqual({
+        method: 'x',
+        id: 'y',
+        path: '/path~with-tilde',
+        did: 'did:x:y',
+        didUrl: 'did:x:y/path~with-tilde',
+      })
+      expect(parseStrict('did:x:y/path!$&()*+,;=')).toEqual({
+        method: 'x',
+        id: 'y',
+        path: '/path!$&()*+,;=',
+        did: 'did:x:y',
+        didUrl: 'did:x:y/path!$&()*+,;=',
+      })
+      expect(parseStrict('did:x:y//double/slash')).toEqual({
+        method: 'x',
+        id: 'y',
+        path: '//double/slash',
+        did: 'did:x:y',
+        didUrl: 'did:x:y//double/slash',
+      })
+    })
+
+    it('supports lowercase hex in percent-encoding', () => {
+      expect(parseStrict('did:x:y%3a')).toEqual({
+        method: 'x',
+        id: 'y%3a',
+        did: 'did:x:y%3a',
+        didUrl: 'did:x:y%3a',
+      })
+      expect(parseStrict('did:x:y%2f%3apath')).toEqual({
+        method: 'x',
+        id: 'y%2f%3apath',
+        did: 'did:x:y%2f%3apath',
+        didUrl: 'did:x:y%2f%3apath',
+      })
+    })
+
+    it('allows empty idchar segments', () => {
+      expect(parseStrict('did:example:id::with::empty::segments')).toEqual({
+        method: 'example',
+        id: 'id::with::empty::segments',
+        did: 'did:example:id::with::empty::segments',
+        didUrl: 'did:example:id::with::empty::segments',
+      })
+    })
+
+    it('rejects matrix parameters', () => {
+      expect(parseStrict('did:example:id;param=value')).toEqual(null)
+      expect(parseStrict('did:example:id;param=value/path')).toEqual(null)
     })
   })
 

--- a/src/__tests__/resolver.test.ts
+++ b/src/__tests__/resolver.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { vi, describe, it, expect, beforeAll } from 'vitest'
-import { Resolver, parse, parseStrict, DIDResolutionResult } from '../resolver'
+import { Resolver, parse, DIDResolutionResult } from '../resolver'
 
 describe('resolver', () => {
   describe('parse()', () => {
@@ -52,40 +52,6 @@ describe('resolver', () => {
         did: 'did:nacl:Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI',
         didUrl: 'did:nacl:Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI',
       })
-      expect(parse('did:example:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high')).toEqual({
-        method: 'example',
-        id: '21tDAKCERh95uGgKbJNHYp',
-        did: 'did:example:21tDAKCERh95uGgKbJNHYp',
-        didUrl: 'did:example:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high',
-        params: {
-          service: 'agent',
-          'foo:bar': 'high',
-        },
-      })
-      expect(parse('did:example:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high?foo=bar')).toEqual({
-        method: 'example',
-        id: '21tDAKCERh95uGgKbJNHYp',
-        didUrl: 'did:example:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high?foo=bar',
-        did: 'did:example:21tDAKCERh95uGgKbJNHYp',
-        query: 'foo=bar',
-        params: {
-          service: 'agent',
-          'foo:bar': 'high',
-        },
-      })
-      expect(parse('did:example:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high/some/path?foo=bar#key1')).toEqual({
-        method: 'example',
-        id: '21tDAKCERh95uGgKbJNHYp',
-        didUrl: 'did:example:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high/some/path?foo=bar#key1',
-        did: 'did:example:21tDAKCERh95uGgKbJNHYp',
-        query: 'foo=bar',
-        path: '/some/path',
-        fragment: 'key1',
-        params: {
-          service: 'agent',
-          'foo:bar': 'high',
-        },
-      })
       expect(parse('did:web:example.com%3A8443')).toEqual({
         method: 'web',
         id: 'example.com%3A8443',
@@ -97,21 +63,6 @@ describe('resolver', () => {
         id: 'example.com:path:some%2Bsubpath',
         didUrl: 'did:web:example.com:path:some%2Bsubpath',
         did: 'did:web:example.com:path:some%2Bsubpath',
-      })
-      expect(
-        parse('did:example:test:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high/some/path?foo=bar#key1')
-      ).toEqual({
-        method: 'example',
-        id: 'test:21tDAKCERh95uGgKbJNHYp',
-        didUrl: 'did:example:test:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high/some/path?foo=bar#key1',
-        did: 'did:example:test:21tDAKCERh95uGgKbJNHYp',
-        query: 'foo=bar',
-        path: '/some/path',
-        fragment: 'key1',
-        params: {
-          service: 'agent',
-          'foo:bar': 'high',
-        },
       })
       expect(parse('did:123:test::test2')).toEqual({
         method: '123',
@@ -139,106 +90,30 @@ describe('resolver', () => {
       expect(parse('did:CAP:id')).toEqual(null)
       expect(parse('did:method:id::anotherid%r9')).toEqual(null)
     })
-  })
-
-  describe('parseStrict()', () => {
-    it('returns parts', () => {
-      expect(parseStrict('did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX')).toEqual({
-        method: 'uport',
-        id: '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
-        did: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
-        didUrl: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
-      })
-      expect(parseStrict('did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX/some/path')).toEqual({
-        method: 'uport',
-        id: '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
-        did: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
-        didUrl: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX/some/path',
-        path: '/some/path',
-      })
-      expect(parseStrict('did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX#fragment=123')).toEqual({
-        method: 'uport',
-        id: '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
-        did: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
-        didUrl: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX#fragment=123',
-        fragment: 'fragment=123',
-      })
-      expect(parseStrict('did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX/some/path#fragment=123')).toEqual({
-        method: 'uport',
-        id: '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
-        did: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX',
-        didUrl: 'did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX/some/path#fragment=123',
-        path: '/some/path',
-        fragment: 'fragment=123',
-      })
-      expect(parseStrict('did:nacl:Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI')).toEqual({
-        method: 'nacl',
-        id: 'Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI',
-        did: 'did:nacl:Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI',
-        didUrl: 'did:nacl:Md8JiMIwsapml_FtQ2ngnGftNP5UmVCAUuhnLyAsPxI',
-      })
-      expect(parseStrict('did:web:example.com%3A8443')).toEqual({
-        method: 'web',
-        id: 'example.com%3A8443',
-        didUrl: 'did:web:example.com%3A8443',
-        did: 'did:web:example.com%3A8443',
-      })
-      expect(parseStrict('did:web:example.com:path:some%2Bsubpath')).toEqual({
-        method: 'web',
-        id: 'example.com:path:some%2Bsubpath',
-        didUrl: 'did:web:example.com:path:some%2Bsubpath',
-        did: 'did:web:example.com:path:some%2Bsubpath',
-      })
-      expect(parseStrict('did:123:test::test2')).toEqual({
-        method: '123',
-        id: 'test::test2',
-        didUrl: 'did:123:test::test2',
-        did: 'did:123:test::test2',
-      })
-      expect(parseStrict('did:method:%12%AF')).toEqual({
-        method: 'method',
-        id: '%12%AF',
-        didUrl: 'did:method:%12%AF',
-        did: 'did:method:%12%AF',
-      })
-    })
-
-    it('returns null if non compliant', () => {
-      expect(parseStrict('')).toEqual(null)
-      expect(parseStrict('did:')).toEqual(null)
-      expect(parseStrict('did:uport')).toEqual(null)
-      expect(parseStrict('did:uport:')).toEqual(null)
-      expect(parseStrict('did:uport:1234_12313***')).toEqual(null)
-      expect(parseStrict('2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX')).toEqual(null)
-      expect(parseStrict('did:method:%12%1')).toEqual(null)
-      expect(parseStrict('did:method:%1233%Ay')).toEqual(null)
-      expect(parseStrict('did:CAP:id')).toEqual(null)
-      expect(parseStrict('did:method:id::anotherid%r9')).toEqual(null)
-    })
 
     it('handles query and fragment correctly', () => {
-      expect(parseStrict('did:x:y?key=value')).toEqual({
+      expect(parse('did:x:y?key=value')).toEqual({
         method: 'x',
         id: 'y',
         did: 'did:x:y',
         didUrl: 'did:x:y?key=value',
         query: 'key=value',
       })
-      expect(parseStrict('did:x:y?')).toEqual({
+      expect(parse('did:x:y?')).toEqual({
         method: 'x',
         id: 'y',
         did: 'did:x:y',
         didUrl: 'did:x:y?',
         query: '',
       })
-      expect(parseStrict('did:x:y#')).toEqual({
+      expect(parse('did:x:y#')).toEqual({
         method: 'x',
         id: 'y',
         did: 'did:x:y',
         didUrl: 'did:x:y#',
         fragment: '',
       })
-      expect(parseStrict('did:x:y?query#fragment')).toEqual({
+      expect(parse('did:x:y?query#fragment')).toEqual({
         method: 'x',
         id: 'y',
         did: 'did:x:y',
@@ -249,21 +124,21 @@ describe('resolver', () => {
     })
 
     it('supports RFC 3986 path characters', () => {
-      expect(parseStrict('did:x:y/path~with-tilde')).toEqual({
+      expect(parse('did:x:y/path~with-tilde')).toEqual({
         method: 'x',
         id: 'y',
         path: '/path~with-tilde',
         did: 'did:x:y',
         didUrl: 'did:x:y/path~with-tilde',
       })
-      expect(parseStrict('did:x:y/path!$&()*+,;=')).toEqual({
+      expect(parse('did:x:y/path!$&()*+,;=')).toEqual({
         method: 'x',
         id: 'y',
         path: '/path!$&()*+,;=',
         did: 'did:x:y',
         didUrl: 'did:x:y/path!$&()*+,;=',
       })
-      expect(parseStrict('did:x:y//double/slash')).toEqual({
+      expect(parse('did:x:y//double/slash')).toEqual({
         method: 'x',
         id: 'y',
         path: '//double/slash',
@@ -273,13 +148,13 @@ describe('resolver', () => {
     })
 
     it('supports lowercase hex in percent-encoding', () => {
-      expect(parseStrict('did:x:y%3a')).toEqual({
+      expect(parse('did:x:y%3a')).toEqual({
         method: 'x',
         id: 'y%3a',
         did: 'did:x:y%3a',
         didUrl: 'did:x:y%3a',
       })
-      expect(parseStrict('did:x:y%2f%3apath')).toEqual({
+      expect(parse('did:x:y%2f%3apath')).toEqual({
         method: 'x',
         id: 'y%2f%3apath',
         did: 'did:x:y%2f%3apath',
@@ -288,7 +163,7 @@ describe('resolver', () => {
     })
 
     it('allows empty idchar segments', () => {
-      expect(parseStrict('did:example:id::with::empty::segments')).toEqual({
+      expect(parse('did:example:id::with::empty::segments')).toEqual({
         method: 'example',
         id: 'id::with::empty::segments',
         did: 'did:example:id::with::empty::segments',
@@ -297,8 +172,8 @@ describe('resolver', () => {
     })
 
     it('rejects matrix parameters', () => {
-      expect(parseStrict('did:example:id;param=value')).toEqual(null)
-      expect(parseStrict('did:example:id;param=value/path')).toEqual(null)
+      expect(parse('did:example:id;param=value')).toEqual(null)
+      expect(parse('did:example:id;param=value/path')).toEqual(null)
     })
   })
 

--- a/src/__tests__/resolver.test.ts
+++ b/src/__tests__/resolver.test.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { vi, describe, it, expect, beforeAll } from 'vitest'
-import { Resolver, parse, DIDResolutionResult } from '../resolver'
+import { vi, describe, it, expect, beforeAll, Mock } from 'vitest'
+import { Resolver, parse, DIDResolver, DIDResolutionResult } from '../resolver'
 
 describe('resolver', () => {
   describe('parse()', () => {
@@ -179,8 +179,7 @@ describe('resolver', () => {
 
   describe('resolve', () => {
     let resolver: Resolver
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let mockmethod: any
+    let mockmethod: Mock<Parameters<DIDResolver>, ReturnType<DIDResolver>>
     const mockReturn = Promise.resolve({
       didResolutionMetadata: { contentType: 'application/did+json' },
       didDocument: {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -77,11 +77,7 @@ export interface DIDDocumentMetadata extends Extensible {
  * @see {@link https://www.w3.org/TR/did-core/#verification-relationships}
  */
 export type KeyCapabilitySection =
-  | 'authentication'
-  | 'assertionMethod'
-  | 'keyAgreement'
-  | 'capabilityInvocation'
-  | 'capabilityDelegation'
+  'authentication' | 'assertionMethod' | 'keyAgreement' | 'capabilityInvocation' | 'capabilityDelegation'
 
 /**
  * Represents a DID document.
@@ -317,6 +313,58 @@ export function parse(didUrl: string): ParsedDID | null {
   return null
 }
 
+// RFC 3986 ABNF components (referenced by DID Core v1.0 §3.2)
+const STRICT_HEXDIG = '[0-9a-fA-F]' // allows both lowercase and uppercase
+const STRICT_PCT_ENCODED = `(?:%${STRICT_HEXDIG}{2})` // pct-encoded = "%" HEXDIG HEXDIG
+
+// DID Core v1.0 §3.1
+const STRICT_ID_CHAR = `(?:[a-zA-Z0-9._-]|${STRICT_PCT_ENCODED})` // idchar
+const STRICT_METHOD = '[a-z0-9]+' // method-name = 1*(%x61-7A / DIGIT)
+const STRICT_METHOD_ID = `(?:${STRICT_ID_CHAR}*:)*${STRICT_ID_CHAR}+` // method-specific-id
+
+// DID Core v1.0 §3.2 tail via RFC 3986 §3.3
+const STRICT_UNRESERVED = '[a-zA-Z0-9._~-]'
+const STRICT_SUB_DELIMS = "[!$&'()*+,;=]"
+const STRICT_PCHAR = `(?:${STRICT_UNRESERVED}|${STRICT_PCT_ENCODED}|${STRICT_SUB_DELIMS}|[:@])` // pchar
+const STRICT_PATH_ABEMPTY = `(?:/${STRICT_PCHAR}*)*` // path-abempty
+const STRICT_QUERY_CHARS = `(?:${STRICT_PCHAR}|[/?])*` // query
+const STRICT_FRAGMENT_CHARS = `(?:${STRICT_PCHAR}|[/?])*` // fragment
+
+const DID_URL_MATCHER = new RegExp(
+  `^did:(${STRICT_METHOD}):(${STRICT_METHOD_ID})(${STRICT_PATH_ABEMPTY})(?:\\?(${STRICT_QUERY_CHARS}))?(?:#(${STRICT_FRAGMENT_CHARS}))?$`
+)
+
+/**
+ * Parses a DID URL strictly according to the DID Core v1.1 specification ABNF
+ * (§3.1 DID Syntax, §3.2 DID URL Syntax). Unlike {@link parse}, this method
+ * does not accept legacy DID parameters (`;key=value`) and enforces the
+ * RFC 3986 character sets for path, query, and fragment components.
+ *
+ * @param didUrl - the DID URL string to be parsed
+ * @returns a ParsedDID object, or null if the input does not conform to the spec
+ */
+export function parseStrict(didUrl: string): ParsedDID | null {
+  if (!didUrl) return null
+  const m = didUrl.match(DID_URL_MATCHER)
+  if (!m) return null
+
+  const parsed: ParsedDID = {
+    did: `did:${m[1]}:${m[2]}`,
+    method: m[1],
+    id: m[2],
+    didUrl,
+  }
+  // path-abempty always matches (possibly empty); only attach a real path.
+  if (m[3]) parsed.path = m[3]
+  // query/fragment groups are `undefined` when absent, `''` when present but empty
+  // (`did:x:y?` / `did:x:y#`), preserve the distinction.
+  if (m[4] !== undefined) parsed.query = m[4]
+  if (m[5] !== undefined) parsed.fragment = m[5]
+  // params are intentionally omitted (matrix parameters not in DID Core v1.1 spec)
+
+  return parsed
+}
+
 const EMPTY_RESULT: DIDResolutionResult = {
   didResolutionMetadata: {},
   didDocument: null,
@@ -374,6 +422,24 @@ export class Resolver implements Resolvable {
 
   async resolve(didUrl: string, options: DIDResolutionOptions = {}): Promise<DIDResolutionResult> {
     const parsed = parse(didUrl)
+    if (parsed === null) {
+      return {
+        ...EMPTY_RESULT,
+        didResolutionMetadata: { error: 'invalidDid' },
+      }
+    }
+    const resolver = this.registry[parsed.method]
+    if (!resolver) {
+      return {
+        ...EMPTY_RESULT,
+        didResolutionMetadata: { error: 'unsupportedDidMethod' },
+      }
+    }
+    return this.cache(parsed, () => resolver(parsed.did, parsed, this, options))
+  }
+
+  async resolveStrict(didUrl: string, options: DIDResolutionOptions = {}): Promise<DIDResolutionResult> {
+    const parsed = parseStrict(didUrl)
     if (parsed === null) {
       return {
         ...EMPTY_RESULT,

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -336,13 +336,12 @@ export function wrapLegacyResolver(resolve: LegacyDIDResolver): DIDResolver {
         didResolutionMetadata: { contentType: 'application/did+ld+json' },
         didDocument: doc,
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
+    } catch (e: unknown) {
       return {
         ...EMPTY_RESULT,
         didResolutionMetadata: {
           error: 'notFound',
-          message: e.toString(), // This is not in spec, but may be helpful
+          message: String(e), // This is not in spec, but may be helpful
         },
       }
     }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -227,14 +227,20 @@ export interface ParsedDID {
 }
 
 /**
- * The DID resolution function that DID Resolver implementations must implement.
+ * Optional parser function that can be attached to a DIDResolver to provide
+ * method-specific validation of the ParsedDID before resolution.
  */
-export type DIDResolver = (
-  did: string,
-  parsed: ParsedDID,
-  resolver: Resolvable,
-  options: DIDResolutionOptions
-) => Promise<DIDResolutionResult>
+export type DIDParser = (parsed: ParsedDID) => ParsedDID | null
+
+/**
+ * The DID resolution function that DID Resolver implementations must implement.
+ * Can optionally have a `.parser` property for method-specific DID validation.
+ */
+export interface DIDResolver {
+  (did: string, parsed: ParsedDID, resolver: Resolvable, options: DIDResolutionOptions): Promise<DIDResolutionResult>
+  parser?: DIDParser
+}
+
 export type WrappedResolver = () => Promise<DIDResolutionResult>
 export type DIDCache = (parsed: ParsedDID, resolve: WrappedResolver, options?: DIDResolutionOptions) => Promise<DIDResolutionResult>
 export type LegacyDIDResolver = (did: string, parsed: ParsedDID, resolver: Resolvable) => Promise<DIDDocument>
@@ -379,13 +385,14 @@ export class Resolver implements Resolvable {
   }
 
   async resolve(didUrl: string, options: DIDResolutionOptions = {}): Promise<DIDResolutionResult> {
-    const parsed = parse(didUrl)
+    let parsed = parse(didUrl)
     if (parsed === null) {
       return {
         ...EMPTY_RESULT,
         didResolutionMetadata: { error: 'invalidDid' },
       }
     }
+
     const resolver = this.registry[parsed.method]
     if (!resolver) {
       return {
@@ -393,6 +400,19 @@ export class Resolver implements Resolvable {
         didResolutionMetadata: { error: 'unsupportedDidMethod' },
       }
     }
+
+    // Use resolver's method-specific parser if available for additional validation
+    if (resolver.parser) {
+      const refined = resolver.parser(parsed)
+      if (refined === null) {
+        return {
+          ...EMPTY_RESULT,
+          didResolutionMetadata: { error: 'invalidDid' },
+        }
+      }
+      parsed = refined
+    }
+
     return this.cache(parsed, () => resolver(parsed.did, parsed, this, options), options)
   }
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -43,6 +43,7 @@ export interface DIDResolutionResult {
  */
 export interface DIDResolutionOptions extends Extensible {
   accept?: string
+  cache?: boolean
 }
 
 /**
@@ -235,7 +236,7 @@ export type DIDResolver = (
   options: DIDResolutionOptions
 ) => Promise<DIDResolutionResult>
 export type WrappedResolver = () => Promise<DIDResolutionResult>
-export type DIDCache = (parsed: ParsedDID, resolve: WrappedResolver) => Promise<DIDResolutionResult>
+export type DIDCache = (parsed: ParsedDID, resolve: WrappedResolver, options?: DIDResolutionOptions) => Promise<DIDResolutionResult>
 export type LegacyDIDResolver = (did: string, parsed: ParsedDID, resolver: Resolvable) => Promise<DIDDocument>
 
 export type ResolverRegistry = Record<string, DIDResolver>
@@ -251,8 +252,8 @@ export interface ResolverOptions {
 
 export function inMemoryCache(): DIDCache {
   const cache: Map<string, DIDResolutionResult> = new Map()
-  return async (parsed: ParsedDID, resolve) => {
-    if (parsed.params && parsed.params['no-cache'] === 'true') return await resolve()
+  return async (parsed: ParsedDID, resolve, options) => {
+    if (options?.cache === false) return await resolve()
 
     const cached = cache.get(parsed.didUrl)
     if (cached !== undefined) return cached
@@ -365,7 +366,10 @@ export class Resolver implements Resolvable {
 
   constructor(registry: ResolverRegistry = {}, options: ResolverOptions = {}) {
     this.registry = registry
-    this.cache = options.cache === true ? inMemoryCache() : options.cache || noCache
+    this.cache =
+      options.cache === true ? inMemoryCache() :
+      options.cache === false ? noCache :
+      options.cache || noCache
     if (options.legacyResolvers) {
       Object.keys(options.legacyResolvers).map((methodName) => {
         if (!this.registry[methodName]) {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -223,7 +223,6 @@ export interface ParsedDID {
   path?: string
   fragment?: string
   query?: string
-  params?: Params
 }
 
 /**
@@ -269,73 +268,29 @@ export function noCache(parsed: ParsedDID, resolve: WrappedResolver): Promise<DI
   return resolve()
 }
 
-const PCT_ENCODED = '(?:%[0-9a-fA-F]{2})'
-const ID_CHAR = `(?:[a-zA-Z0-9._-]|${PCT_ENCODED})`
-const METHOD = '([a-z0-9]+)'
-const METHOD_ID = `((?:${ID_CHAR}*:)*(${ID_CHAR}+))`
-const PARAM_CHAR = '[a-zA-Z0-9_.:%-]'
-const PARAM = `;${PARAM_CHAR}+=${PARAM_CHAR}*`
-const PARAMS = `((${PARAM})*)`
-const PATH = `(/[^#?]*)?`
-const QUERY = `([?][^#]*)?`
-const FRAGMENT = `(#.*)?`
-const DID_MATCHER = new RegExp(`^did:${METHOD}:${METHOD_ID}${PARAMS}${PATH}${QUERY}${FRAGMENT}$`)
-
-/**
- * Parses a DID URL and builds a {@link ParsedDID | ParsedDID object}
- *
- * @param didUrl - the DID URL string to be parsed
- * @returns a ParsedDID object, or null if the input is not a DID URL
- */
-export function parse(didUrl: string): ParsedDID | null {
-  if (didUrl === '' || !didUrl) return null
-  const sections = didUrl.match(DID_MATCHER)
-  if (sections) {
-    const parts: ParsedDID = {
-      did: `did:${sections[1]}:${sections[2]}`,
-      method: sections[1],
-      id: sections[2],
-      didUrl,
-    }
-    if (sections[4]) {
-      const params = sections[4].slice(1).split(';')
-      parts.params = {}
-      for (const p of params) {
-        const kv = p.split('=')
-        parts.params[kv[0]] = kv[1]
-      }
-    }
-    if (sections[6]) parts.path = sections[6]
-    if (sections[7]) parts.query = sections[7].slice(1)
-    if (sections[8]) parts.fragment = sections[8].slice(1)
-    return parts
-  }
-  return null
-}
-
 // RFC 3986 ABNF components (referenced by DID Core v1.0 §3.2)
-const STRICT_HEXDIG = '[0-9a-fA-F]' // allows both lowercase and uppercase
-const STRICT_PCT_ENCODED = `(?:%${STRICT_HEXDIG}{2})` // pct-encoded = "%" HEXDIG HEXDIG
+const HEXDIG = '[0-9a-fA-F]' // allows both lowercase and uppercase
+const PCT_ENCODED = `(?:%${HEXDIG}{2})` // pct-encoded = "%" HEXDIG HEXDIG
 
 // DID Core v1.0 §3.1
-const STRICT_ID_CHAR = `(?:[a-zA-Z0-9._-]|${STRICT_PCT_ENCODED})` // idchar
-const STRICT_METHOD = '[a-z0-9]+' // method-name = 1*(%x61-7A / DIGIT)
-const STRICT_METHOD_ID = `(?:${STRICT_ID_CHAR}*:)*${STRICT_ID_CHAR}+` // method-specific-id
+const ID_CHAR = `(?:[a-zA-Z0-9._-]|${PCT_ENCODED})` // idchar
+const METHOD = '[a-z0-9]+' // method-name = 1*(%x61-7A / DIGIT)
+const METHOD_ID = `(?:${ID_CHAR}*:)*${ID_CHAR}+` // method-specific-id
 
 // DID Core v1.0 §3.2 tail via RFC 3986 §3.3
-const STRICT_UNRESERVED = '[a-zA-Z0-9._~-]'
-const STRICT_SUB_DELIMS = "[!$&'()*+,;=]"
-const STRICT_PCHAR = `(?:${STRICT_UNRESERVED}|${STRICT_PCT_ENCODED}|${STRICT_SUB_DELIMS}|[:@])` // pchar
-const STRICT_PATH_ABEMPTY = `(?:/${STRICT_PCHAR}*)*` // path-abempty
-const STRICT_QUERY_CHARS = `(?:${STRICT_PCHAR}|[/?])*` // query
-const STRICT_FRAGMENT_CHARS = `(?:${STRICT_PCHAR}|[/?])*` // fragment
+const UNRESERVED = '[a-zA-Z0-9._~-]'
+const SUB_DELIMS = "[!$&'()*+,;=]"
+const PCHAR = `(?:${UNRESERVED}|${PCT_ENCODED}|${SUB_DELIMS}|[:@])` // pchar
+const PATH_ABEMPTY = `(?:/${PCHAR}*)*` // path-abempty
+const QUERY_CHARS = `(?:${PCHAR}|[/?])*` // query
+const FRAGMENT_CHARS = `(?:${PCHAR}|[/?])*` // fragment
 
 const DID_URL_MATCHER = new RegExp(
-  `^did:(${STRICT_METHOD}):(${STRICT_METHOD_ID})(${STRICT_PATH_ABEMPTY})(?:\\?(${STRICT_QUERY_CHARS}))?(?:#(${STRICT_FRAGMENT_CHARS}))?$`
+  `^did:(${METHOD}):(${METHOD_ID})(${PATH_ABEMPTY})(?:\\?(${QUERY_CHARS}))?(?:#(${FRAGMENT_CHARS}))?$`
 )
 
 /**
- * Parses a DID URL strictly according to the DID Core v1.1 specification ABNF
+ * Parses a DID URL strictly according to the DID Core v1.0 specification ABNF
  * (§3.1 DID Syntax, §3.2 DID URL Syntax). Unlike {@link parse}, this method
  * does not accept legacy DID parameters (`;key=value`) and enforces the
  * RFC 3986 character sets for path, query, and fragment components.
@@ -343,7 +298,7 @@ const DID_URL_MATCHER = new RegExp(
  * @param didUrl - the DID URL string to be parsed
  * @returns a ParsedDID object, or null if the input does not conform to the spec
  */
-export function parseStrict(didUrl: string): ParsedDID | null {
+export function parse(didUrl: string): ParsedDID | null {
   if (!didUrl) return null
   const m = didUrl.match(DID_URL_MATCHER)
   if (!m) return null
@@ -360,7 +315,7 @@ export function parseStrict(didUrl: string): ParsedDID | null {
   // (`did:x:y?` / `did:x:y#`), preserve the distinction.
   if (m[4] !== undefined) parsed.query = m[4]
   if (m[5] !== undefined) parsed.fragment = m[5]
-  // params are intentionally omitted (matrix parameters not in DID Core v1.1 spec)
+  // params are intentionally omitted (matrix parameters not in DID Core v1.0 spec)
 
   return parsed
 }
@@ -435,24 +390,6 @@ export class Resolver implements Resolvable {
         didResolutionMetadata: { error: 'unsupportedDidMethod' },
       }
     }
-    return this.cache(parsed, () => resolver(parsed.did, parsed, this, options))
-  }
-
-  async resolveStrict(didUrl: string, options: DIDResolutionOptions = {}): Promise<DIDResolutionResult> {
-    const parsed = parseStrict(didUrl)
-    if (parsed === null) {
-      return {
-        ...EMPTY_RESULT,
-        didResolutionMetadata: { error: 'invalidDid' },
-      }
-    }
-    const resolver = this.registry[parsed.method]
-    if (!resolver) {
-      return {
-        ...EMPTY_RESULT,
-        didResolutionMetadata: { error: 'unsupportedDidMethod' },
-      }
-    }
-    return this.cache(parsed, () => resolver(parsed.did, parsed, this, options))
+    return this.cache(parsed, () => resolver(parsed.did, parsed, this, options), options)
   }
 }


### PR DESCRIPTION
NB Built on #163, will rebase if merged

`DID Core v1.0` enables specific DID methods to apply stricter syntax requirements atop the base requirements of `DID Core v1.0`

Enable custom per-method parsers to be wrapped in `getResolver()` so that each method can control their own stricter syntactic parsing atop the `DID Core v1.0` parser

